### PR TITLE
feat: expose paramsSummaryMultiqc as @Function

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -2,7 +2,7 @@ plugins {
     id 'io.nextflow.nextflow-plugin' version '1.0.0-beta.12'
 }
 
-version = '0.4.0'
+version = '0.5.0'
 
 nextflowPlugin {
     nextflowVersion = '25.10.0'

--- a/src/main/groovy/nfcore/plugin/NfUtilsExtension.groovy
+++ b/src/main/groovy/nfcore/plugin/NfUtilsExtension.groovy
@@ -544,4 +544,14 @@ class NfUtilsExtension extends PluginExtensionPoint {
         return NfcoreCitationUtils.autoToolBibliographyText(topicCitations)
     }
 
+    /**
+     * Generate workflow summary for MultiQC
+     * @param summaryParams Map of parameter groups and their parameters
+     * @return YAML formatted string for MultiQC
+     */
+    @Function
+    String paramsSummaryMultiqc(Map summaryParams) {
+        return nfcore.plugin.nfcore.NfcoreReportingUtils.paramsSummaryMultiqc(summaryParams)
+    }
+
 }


### PR DESCRIPTION
## Summary
- Expose `paramsSummaryMultiqc` as a `@Function` in `NfUtilsExtension.groovy`, delegating to existing `NfcoreReportingUtils.paramsSummaryMultiqc()`
- Bump version from 0.4.0 to 0.5.0
- Enables pipelines to `include { paramsSummaryMultiqc } from 'plugin/nf-core-utils'` instead of importing from legacy `utils_nfcore_pipeline` subworkflow

## Test plan
- [x] `./gradlew test` passes
- [x] `./gradlew build` succeeds
- [x] Verified end-to-end with nf-core/methylseq migration (default nf-test passes)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: small API surface addition and a version bump, with no changes to the underlying reporting logic beyond a new delegating wrapper.
> 
> **Overview**
> Exposes `paramsSummaryMultiqc` as a Nextflow `@Function` on `NfUtilsExtension`, delegating to the existing `NfcoreReportingUtils.paramsSummaryMultiqc()` so pipelines can import it directly from the plugin.
> 
> Bumps the plugin version in `build.gradle` from `0.4.0` to `0.5.0`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 59f4a624ae2c2c89ef0fff7031062f88cb8d95ef. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->