### PR TITLE
docs: add self-driving documentation structure for autonomous contributors

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,88 @@
+# AGENTS.md — Autonomous Contributor Guide
+
+> **Audience**: AI agents (Claude, Codex, Gemini, etc.) and autonomous contributors.
+> **Purpose**: Tell every agent exactly how to orient, navigate, and deliver work in this repo without human hand-holding.
+
+---
+
+## 1. What This Repo Is
+
+**nf-core-utils** is a [Nextflow PF4J plugin](https://www.nextflow.io/docs/latest/plugins.html) that ships utility functions used by nf-core community pipelines. It replaces the legacy `utils_nextflow_pipeline` and related subworkflows with a clean, versioned plugin surface.
+
+Key domains:
+
+| Domain | Entry point | Purpose |
+|--------|-------------|---------|
+| Pipeline utilities | `NfUtilsExtension.groovy` | Version strings, param export, conda validation |
+| Configuration validation | `NfcoreConfigValidator` | Profile & config correctness |
+| Notifications | `NfcoreNotificationUtils` | Email, Slack, Teams, terminal summaries |
+| Reporting / MultiQC | `NfcoreReportingOrchestrator` | Versions, citations, bibliography, methods |
+| References | `ReferencesUtils` | igenomes + custom reference resolution |
+
+See [`ARCHITECTURE.md`](ARCHITECTURE.md) for the structural map and [`docs/DESIGN.md`](docs/DESIGN.md) for design rationale.
+
+---
+
+## 2. Orientation Checklist
+
+Before touching code, an agent SHOULD:
+
+1. Read [`CLAUDE.md`](CLAUDE.md) — build commands, test commands, key config files.
+2. Read [`ARCHITECTURE.md`](ARCHITECTURE.md) — layer diagram and module map.
+3. Read [`docs/DESIGN.md`](docs/DESIGN.md) — design constraints and patterns.
+4. Skim [`CHANGELOG.md`](CHANGELOG.md) — understand recent velocity.
+5. Check [`docs/exec-plans/active/`](docs/exec-plans/active/) — are there in-flight plans that affect your task?
+
+---
+
+## 3. Development Workflow
+
+```
+make assemble    # compile
+make test        # run Spock unit tests
+make install     # install plugin locally for integration testing
+nextflow run hello -plugins nf-core-utils@<version>   # smoke test
+```
+
+All tests live in `src/test/groovy/nfcore/plugin/` and use **Spock** framework.
+
+---
+
+## 4. Code Conventions
+
+- **Language**: Groovy (JVM); Nextflow DSL2 in examples.
+- **Style**: Static utility methods preferred; extension methods delegate to utility classes for testability.
+- **Statefulness**: Utility classes are intentionally stateless.
+- **No breaking changes** to public `@Function`-annotated methods without a major version bump.
+- Follow existing package naming: `nfcore.plugin.*`.
+
+---
+
+## 5. PR / Commit Norms
+
+- Atomic commits; one logical change per commit.
+- Commit message: `<type>(<scope>): <short description>` (Conventional Commits).
+- Update `CHANGELOG.md` under `[Unreleased]` for every user-visible change.
+- New public functions require at minimum a Spock unit test and a docs entry under `docs/`.
+
+---
+
+## 6. Doc Locations
+
+| Question | Where to look |
+|----------|---------------|
+| What are we building next? | [`docs/exec-plans/active/`](docs/exec-plans/active/) |
+| Why does X work this way? | [`docs/design-docs/`](docs/design-docs/) |
+| What are tech-debt items? | [`docs/exec-plans/tech-debt-tracker.md`](docs/exec-plans/tech-debt-tracker.md) |
+| Security posture | [`docs/SECURITY.md`](docs/SECURITY.md) |
+| Quality standards | [`docs/QUALITY_SCORE.md`](docs/QUALITY_SCORE.md) |
+| Reliability targets | [`docs/RELIABILITY.md`](docs/RELIABILITY.md) |
+
+---
+
+## 7. Things Agents Must NOT Do
+
+- Do **not** delete or rename existing `docs/` files without explicit instruction.
+- Do **not** modify `version` in `build.gradle` unless executing a release plan.
+- Do **not** add external runtime dependencies without updating `docs/DESIGN.md` and the tech-debt tracker.
+- Do **not** merge work that reduces test coverage below the current baseline.

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -1,0 +1,150 @@
+# ARCHITECTURE.md — System Architecture
+
+> Living document. Update whenever the layer diagram or module boundaries change.
+
+---
+
+## 1. High-Level Layer Diagram
+
+```
+┌───────────────────────────────────────────────────────────────┐
+│                   Nextflow Pipeline (user)                     │
+│   include { fn } from 'plugin/nf-core-utils'                  │
+└──────────────────────────┬────────────────────────────────────┘
+                           │  @Function annotations
+┌──────────────────────────▼────────────────────────────────────┐
+│               Extension Layer  (PF4J entry points)            │
+│  NfUtilsPlugin.groovy  ·  NfUtilsExtension.groovy             │
+│  NfcorePipelineObserverFactory.groovy                         │
+└──────┬───────────┬──────────────┬────────────────┬────────────┘
+       │           │              │                │
+┌──────▼───┐ ┌────▼──────┐ ┌────▼──────┐ ┌───────▼───────────┐
+│ Nextflow │ │  nf-core  │ │References │ │    Reporting /     │
+│ Pipeline │ │ Utilities │ │ Extension │ │    Orchestrator    │
+│ Utils    │ │           │ │           │ │                    │
+└──────────┘ └───────────┘ └───────────┘ └────────────────────┘
+```
+
+---
+
+## 2. Package Map
+
+All source lives under `src/main/groovy/nfcore/plugin/`:
+
+```
+nfcore/plugin/
+├── NfUtilsPlugin.groovy              # BasePlugin subclass; PF4J entry point
+├── NfUtilsExtension.groovy           # @Function declarations; thin delegates
+├── NfcorePipelineObserver.groovy     # Trace observer for lifecycle events
+├── NfcorePipelineObserverFactory.groovy
+└── nfcore/
+    ├── NfcoreConfigValidator.groovy      # Profile/config validation
+    ├── NfcoreNotificationUtils.groovy    # Email, Slack, Teams, terminal output
+    ├── NfcoreReportingUtils.groovy       # MultiQC, pipeline summaries
+    ├── NfcoreVersionUtils.groovy         # Version aggregation, YAML, channels
+    ├── NfcoreCitationUtils.groovy        # Citation extraction from meta.yml
+    └── NfcoreReportingOrchestrator.groovy # Composes version+citation+bib+methods
+```
+
+And the sibling packages:
+
+```
+nfcore/plugin/
+├── nextflow/
+│   └── NextflowPipelineUtils.groovy   # getWorkflowVersion, dumpParametersToJSON, checkCondaChannels
+└── references/
+    └── ReferencesUtils.groovy         # getReferencesFile, getReferencesValue
+```
+
+---
+
+## 3. Key Design Decisions
+
+| Decision | Rationale |
+|----------|-----------|
+| Stateless utility classes | Simplifies testing; no shared mutable state across pipeline runs |
+| Extension methods delegate to utility classes | Thin extension surface; business logic is independently testable |
+| Single external dependency (SnakeYAML) | Keeps the plugin lightweight; YAML is required for meta.yml parsing |
+| PF4J plugin model | Standard Nextflow plugin contract; enables versioning via the plugin registry |
+| Groovy (not Java) | Aligns with Nextflow's own language; richer DSL for expression of pipeline idioms |
+
+See [`docs/design-docs/`](docs/design-docs/) for per-decision ADRs and [`docs/design-docs/core-beliefs.md`](docs/design-docs/core-beliefs.md) for principles.
+
+---
+
+## 4. Data & Control Flow
+
+### 4.1 Version String Generation
+
+```
+workflow.manifest.version + workflow.commitId
+        │
+        ▼
+NextflowPipelineUtils.getWorkflowVersion()
+        │  applies: 'v' prefix, 7-char git hash, 'g' prefix
+        ▼
+"v1.2.0-gabc1234"  →  log / published to channels
+```
+
+### 4.2 Reporting Pipeline
+
+```
+NfcoreVersionUtils (collect versions from YAML channels)
+        +
+NfcoreCitationUtils (parse meta.yml citations)
+        │
+        ▼
+NfcoreReportingOrchestrator.generateCompleteReport()
+        │
+        ├── MultiQC versions YAML
+        ├── Citations / bibliography
+        └── Methods description (Markdown)
+```
+
+### 4.3 Observer Lifecycle
+
+```
+Nextflow session start
+        │
+NfcorePipelineObserverFactory.create()
+        │
+NfcorePipelineObserver (registered with Nextflow trace subsystem)
+        │  onFlowCreate / onFlowComplete / onProcessComplete
+        └── delegates to NfcoreNotificationUtils / NfcoreReportingUtils
+```
+
+---
+
+## 5. Testing Architecture
+
+```
+src/test/groovy/nfcore/plugin/
+├── nextflow/      NextflowPipelineTest.groovy
+├── nfcore/        NfcoreVersionUtilsTest.groovy
+│                  NfcoreReportingOrchestratorTest.groovy
+│                  … (one test per utility class)
+└── references/    ReferencesTest.groovy
+```
+
+- Framework: **Spock** (Groovy BDD).
+- Test resources: `src/test/resources/` (YAML fixtures, mock configs).
+- Run: `make test` or `./gradlew test`.
+
+---
+
+## 6. Build & Release
+
+| Step | Command |
+|------|---------|
+| Compile | `make assemble` |
+| Test | `make test` |
+| Local install | `make install` |
+| Release | `make release` (requires `~/.gradle/gradle.properties` with GitHub credentials) |
+
+Plugin version lives in `build.gradle` → `version`. Nextflow compatibility floor: `25.10.0`.
+
+---
+
+## 7. Future Architecture Considerations
+
+Tracked in [`docs/exec-plans/active/`](docs/exec-plans/active/) and [`docs/exec-plans/tech-debt-tracker.md`](docs/exec-plans/tech-debt-tracker.md).

--- a/docs/DESIGN.md
+++ b/docs/DESIGN.md
@@ -1,0 +1,79 @@
+# DESIGN.md — Design Philosophy & Patterns
+
+> Companion to [`ARCHITECTURE.md`](../ARCHITECTURE.md) and [`docs/design-docs/core-beliefs.md`](design-docs/core-beliefs.md).
+> ARCHITECTURE.md describes structure; this file describes *how and why* we make design choices.
+
+---
+
+## 1. Design Principles (Short Form)
+
+1. **Thin extension, fat utilities** — `NfUtilsExtension` is a switchboard; logic lives in testable utility classes.
+2. **No surprises** — functions do exactly what their names say; no hidden side effects.
+3. **Fail loudly, fail early** — throw informative exceptions rather than silently returning null or continuing in a broken state.
+4. **Minimal dependencies** — every external library is a risk; justify additions in a design doc.
+5. **Community standards first** — nf-core conventions override local preferences.
+
+Full rationale: [`docs/design-docs/core-beliefs.md`](design-docs/core-beliefs.md).
+
+---
+
+## 2. Patterns in Use
+
+### 2.1 Stateless Utility Classes
+
+All business logic lives in classes with only `static` methods (or methods on stateless instances). This makes every function independently unit-testable with Spock without needing a live Nextflow session.
+
+```groovy
+// ✅ Correct pattern
+class NfcoreVersionUtils {
+    static String formatVersionYaml(Map versions) { … }
+}
+
+// ❌ Avoid
+class NfcoreVersionUtils {
+    Map state   // shared mutable state — don't do this
+    String formatVersionYaml() { state.versions }
+}
+```
+
+### 2.2 Extension as Delegate
+
+`NfUtilsExtension` annotates methods with `@Function` for Nextflow discovery and immediately delegates to a utility class. This keeps the extension surface stable while allowing utility classes to evolve independently.
+
+```groovy
+@Function
+String getWorkflowVersion(String manifestVersion, String commitId) {
+    return NextflowPipelineUtils.getWorkflowVersion(manifestVersion, commitId)
+}
+```
+
+### 2.3 Observer Pattern for Lifecycle Events
+
+Pipeline lifecycle events (start, complete, process complete) are handled by `NfcorePipelineObserver` via Nextflow's trace subsystem. The observer delegates notifications and reporting to utility classes rather than implementing logic inline.
+
+### 2.4 Non-blocking Validation
+
+Validation functions (`checkCondaChannels`, `checkConfigProvided`) are designed to be non-blocking where failures are advisory rather than fatal. Return `boolean`; let the caller decide whether to abort.
+
+---
+
+## 3. Adding a New Feature — Design Checklist
+
+- [ ] Does the feature belong in an existing utility class, or does it need a new one?
+- [ ] Is the new function independently testable without a Nextflow session?
+- [ ] Does it introduce a new external dependency? If yes → create a design doc first.
+- [ ] Is the public API signature stable? If it might change → mark as `@Incubating` in Groovydoc.
+- [ ] Does the function name follow verb-noun camelCase convention?
+- [ ] Are there unit tests covering happy path + at least one failure mode?
+- [ ] Is the function documented in `docs/`?
+
+---
+
+## 4. What Belongs in This Plugin vs. Elsewhere
+
+| Belongs here | Does NOT belong here |
+|---|---|
+| Functions needed by ≥ 3 nf-core pipelines | Pipeline-specific business logic |
+| Cross-cutting nf-core conventions | Workflow process definitions |
+| Utilities that replace legacy subworkflows | nf-core schema validation (use nf-core CLI) |
+| Reference file resolution (igenomes) | HPC/cloud-specific configuration |

--- a/docs/FRONTEND.md
+++ b/docs/FRONTEND.md
@@ -1,0 +1,90 @@
+# FRONTEND.md — User-Facing Interface Guide
+
+> nf-core-utils is a Nextflow plugin library — it has no web frontend or GUI.
+> "Frontend" in this context means **the public API surface** that pipeline authors interact with:
+> the `@Function`-annotated methods in `NfUtilsExtension.groovy`.
+
+---
+
+## 1. Public Function Reference
+
+All functions below are importable via:
+
+```nextflow
+include { <functionName> } from 'plugin/nf-core-utils'
+```
+
+### 1.1 NextflowPipelineExtension functions
+
+| Function | Parameters | Returns | Description |
+|----------|-----------|---------|-------------|
+| `getWorkflowVersion` | `String manifestVersion, String commitId` | `String` | Git-aware version string (e.g. `v1.2.0-gabc1234`) |
+| `dumpParametersToJSON` | `String outdir, Map params, Path launchDir` | `void` | Writes timestamped params JSON to `<outdir>/pipeline_info/` |
+| `checkCondaChannels` | — | `boolean` | Validates conda-forge + bioconda channel order |
+
+### 1.2 NfCoreUtilities functions
+
+| Function | Parameters | Returns | Description |
+|----------|-----------|---------|-------------|
+| `checkConfigProvided` | `Map params, List<String> required` | `void` | Exits with error if required params are missing |
+| `checkProfileProvided` | `String profile` | `void` | Warns if no institutional profile is detected |
+| `completionEmail` | `Map params, Map summary, String multiqcReport` | `void` | Sends completion email if configured |
+| `imNotification` | `Map summary, String hook_url` | `void` | Sends Slack/Teams notification |
+| `completionSummary` | `Map summary` | `void` | Prints completion summary to terminal |
+
+### 1.3 ReferencesExtension functions
+
+| Function | Parameters | Returns | Description |
+|----------|-----------|---------|-------------|
+| `getReferencesFile` | `String genome, String key, Map params` | `Path` | Resolves a reference file path (igenomes or custom) |
+| `getReferencesValue` | `String genome, String key, Map params` | `String` | Resolves a reference scalar value |
+
+---
+
+## 2. Version Compatibility
+
+Plugin version is declared in `build.gradle` → `version`.  
+Nextflow compatibility floor: `nextflowVersion` in `build.gradle` → `nextflowPlugin {}`.
+
+When using this plugin in a pipeline's `nextflow.config`:
+
+```groovy
+plugins {
+    id 'nf-core-utils@0.5.0'
+}
+```
+
+---
+
+## 3. Deprecation Policy
+
+- Deprecated functions are annotated with `@Deprecated` in Groovydoc and emit a `log.warn` at call time.
+- They are removed only in the next **major** version.
+- Replacement guidance is always documented in the deprecation warning and in `CHANGELOG.md`.
+
+---
+
+## 4. Import Patterns
+
+```nextflow
+// Minimal — import only what you need
+include { getWorkflowVersion } from 'plugin/nf-core-utils'
+
+// Grouped — common pattern for full nf-core compliance
+include {
+    checkConfigProvided
+    checkProfileProvided
+    completionEmail
+    completionSummary
+    getWorkflowVersion
+    dumpParametersToJSON
+} from 'plugin/nf-core-utils'
+```
+
+---
+
+## 5. Error Handling Contract
+
+- Functions that validate state throw `nextflow.exception.AbortOperationException` (or call `System.exit(1)`) on fatal errors — pipeline will not proceed.
+- Functions that check advisory state (e.g. `checkCondaChannels`) return `boolean` — pipeline continues regardless.
+- Notification functions swallow errors silently and log a warning — a misconfigured Slack hook must not crash a pipeline.

--- a/docs/PLANS.md
+++ b/docs/PLANS.md
@@ -1,0 +1,64 @@
+# PLANS.md — Roadmap & Execution Plans
+
+> High-level roadmap. Detailed execution plans live in [`docs/exec-plans/active/`](exec-plans/active/).
+> This file is the navigational index — keep it short and current.
+
+---
+
+## Current Focus (Active)
+
+| Plan | Summary | Status |
+|------|---------|--------|
+| (none active) | — | — |
+
+Add a row here when you create a file in `docs/exec-plans/active/`.
+
+---
+
+## Near-Term Priorities
+
+1. **Integration test in CI** — Run a real `nextflow run hello` smoke test against the installed plugin in GitHub Actions. (See [TD-001](exec-plans/tech-debt-tracker.md))
+2. **Observer unit test coverage** — Add Spock specs for `NfcorePipelineObserver` lifecycle methods. (See [TD-003](exec-plans/tech-debt-tracker.md))
+3. **Quick-start onboarding** — Implement acceptance criteria from [PS-001](product-specs/new-user-onboarding.md).
+4. **Auto-generated function reference** — Generate the public function table in `docs/FRONTEND.md` from source rather than maintaining it manually.
+
+---
+
+## Completed Plans
+
+| Plan | Summary | Shipped version |
+|------|---------|-----------------|
+| (none yet) | — | — |
+
+Move completed plans from `docs/exec-plans/active/` → `docs/exec-plans/completed/` and add a row here.
+
+---
+
+## How to Create an Execution Plan
+
+1. Create `docs/exec-plans/active/YYYY-MM-<kebab-title>.md`.
+2. Use this template:
+
+```markdown
+# Exec Plan: <Title>
+
+**Status**: In Progress | Blocked | Review  
+**Target version**: <semver>  
+**Created**: YYYY-MM-DD  
+
+## Objective
+One-sentence goal.
+
+## Tasks
+- [ ] Task 1
+- [ ] Task 2
+
+## Definition of Done
+- Acceptance criteria (what "complete" means)
+
+## Risks / Blockers
+- Known risks or dependencies
+```
+
+3. Link the plan from the "Current Focus" table above.
+4. When shipped: move the file to `docs/exec-plans/completed/`, update `CHANGELOG.md`, and add a row to "Completed Plans".

--- a/docs/PRODUCT_SENSE.md
+++ b/docs/PRODUCT_SENSE.md
@@ -1,0 +1,73 @@
+# PRODUCT_SENSE.md — Product Intuition Guide
+
+> Helps autonomous contributors make good product decisions without asking for approval on every choice.
+> Read this before deciding whether to add a feature, change behaviour, or remove something.
+
+---
+
+## 1. Who Are Our Users?
+
+### Primary: nf-core Pipeline Authors
+- Write Nextflow DSL2 pipelines for bioinformatics workflows.
+- Range from novice (following nf-core templates) to expert (building complex multi-step analyses).
+- Care deeply about reproducibility, community standards, and not breaking their CI.
+- Pain point: boilerplate functions that have to be copy-pasted into every pipeline.
+
+### Secondary: nf-core Community Reviewers
+- Review pull requests against nf-core linting standards.
+- Need the plugin to enforce conventions consistently so review is predictable.
+
+### Tertiary: Autonomous Agents / CI Bots
+- Run automated pipeline checks.
+- Need machine-readable, stable APIs with clear error messages.
+
+---
+
+## 2. What Does "Good" Look Like?
+
+A good addition to nf-core-utils:
+
+- **Eliminates boilerplate** that pipeline authors currently copy-paste.
+- **Has at least 3 pipelines** that could immediately use it (or is mandated by nf-core standards).
+- **Doesn't surprise callers** — naming is self-documenting, behaviour matches expectation.
+- **Is independently testable** — doesn't require a full pipeline execution to unit test.
+- **Has stable API** — if it might change in the next release, mark it `@Incubating`.
+
+A bad addition:
+- Solves a problem for one pipeline but not others.
+- Requires adding a new external library with unclear maintenance story.
+- Changes existing function signatures in a breaking way without a major version bump.
+- Is a workaround for a Nextflow bug that should be fixed upstream.
+
+---
+
+## 3. Decision Heuristics
+
+### "Should we add this function?"
+> Does it replace something currently duplicated across ≥3 nf-core pipelines?
+> → Yes → add it (with tests + docs).
+> → No → probably belongs in the individual pipeline, not here.
+
+### "Should we change this function's signature?"
+> Will it break existing pipeline code?
+> → Yes → this requires a major version bump + deprecation of the old form.
+> → No → it's a compatible addition; add it with a minor version bump.
+
+### "Should we add this dependency?"
+> Is there a stdlib/SnakeYAML equivalent that covers 80% of the need?
+> → Yes → use it.
+> → No → write a design doc and get explicit approval before adding.
+
+### "Should we emit a warning vs. throw an error?"
+> Is the misconfiguration advisory (pipeline can still succeed)?
+> → Yes → `log.warn`; return `false`; let the caller decide.
+> → No → throw / `System.exit(1)`; don't let the pipeline proceed silently broken.
+
+---
+
+## 4. The nf-core Standard as North Star
+
+When in doubt, ask: *"What would the nf-core linter expect here?"*  
+The plugin's purpose is to make it easy to be nf-core compliant. If a feature helps with that, it belongs here. If it diverges from nf-core conventions, it almost certainly doesn't.
+
+Reference: https://nf-co.re/docs/contributing/guidelines

--- a/docs/QUALITY_SCORE.md
+++ b/docs/QUALITY_SCORE.md
@@ -1,0 +1,81 @@
+# QUALITY_SCORE.md — Quality Standards & Scorecard
+
+> Use this as a checklist before merging any PR and as a periodic health check for the codebase.
+
+---
+
+## 1. Quality Dimensions
+
+| Dimension | Definition | Target |
+|-----------|-----------|--------|
+| **Test coverage** | % of utility class methods covered by Spock unit tests | ≥ 80% line coverage |
+| **Public API docs** | All `@Function` methods have a docs entry in `docs/` | 100% |
+| **No broken links** | All relative Markdown links in docs resolve | 100% |
+| **CHANGELOG currency** | Every user-visible change has a CHANGELOG entry | 100% |
+| **Build green** | `make test` passes on latest Nextflow compatibility target | 100% |
+| **No TODO / FIXME** | No untracked `// TODO` or `// FIXME` in committed code | 0 untracked |
+
+---
+
+## 2. Pre-Merge Checklist
+
+Before merging a PR, verify:
+
+- [ ] `make test` passes locally.
+- [ ] New public functions have unit tests (happy path + ≥1 failure mode).
+- [ ] New public functions are documented in `docs/`.
+- [ ] `CHANGELOG.md` updated under `[Unreleased]`.
+- [ ] No new external runtime dependencies without a design doc.
+- [ ] If a breaking API change: version bump + migration guidance in CHANGELOG.
+- [ ] If a new tech-debt item was intentionally introduced: it is logged in [`docs/exec-plans/tech-debt-tracker.md`](exec-plans/tech-debt-tracker.md).
+
+---
+
+## 3. Code Review Standards
+
+### Automatic disqualifiers (PR cannot merge):
+- `make test` fails.
+- Breaking change to a public `@Function` without a major version bump.
+- New external runtime dependency without a design doc.
+
+### Encouraged but not blocking:
+- Groovydoc comments on all public methods.
+- Example usage in docs for complex functions.
+- Removal of pre-existing TODO comments (with proper resolution, not just deletion).
+
+---
+
+## 4. Periodic Health Check
+
+Run this quarterly (or after any significant feature addition):
+
+```bash
+# Check test coverage (requires JaCoCo — add to build.gradle if not present)
+./gradlew jacocoTestReport
+
+# Find untracked TODOs
+grep -r "TODO\|FIXME" src/main/ --include="*.groovy"
+
+# Verify all docs links resolve (use markdown-link-check or similar)
+# npx markdown-link-check docs/**/*.md
+```
+
+---
+
+## 5. Current Quality Status
+
+> Update this section after each quarterly check.
+
+| Check | Last run | Result |
+|-------|----------|--------|
+| Test suite | — | — |
+| Coverage report | — | — |
+| TODO/FIXME audit | — | — |
+| Docs link check | — | — |
+
+---
+
+## 6. Improving Quality Over Time
+
+Quality items are tracked as tech-debt items in [`docs/exec-plans/tech-debt-tracker.md`](exec-plans/tech-debt-tracker.md).
+When a quality gap is identified here, add a corresponding TD item there.

--- a/docs/RELIABILITY.md
+++ b/docs/RELIABILITY.md
@@ -1,0 +1,74 @@
+# RELIABILITY.md — Reliability Standards
+
+> nf-core-utils is infrastructure. Pipelines running in production HPC clusters and cloud environments
+> depend on it. Reliability is a first-class concern.
+
+---
+
+## 1. Reliability Contract
+
+| Concern | Commitment |
+|---------|-----------|
+| **No silent data loss** | Functions that write files (e.g. `dumpParametersToJSON`) must not silently swallow write errors |
+| **No pipeline crashes from advisory checks** | Validation functions that are non-fatal (`checkCondaChannels`) must not throw unhandled exceptions |
+| **Nextflow version compatibility** | The plugin must work against the declared `nextflowVersion` floor in `build.gradle` |
+| **Idempotency** | Functions called multiple times with the same input must produce the same output |
+| **No shared mutable state** | Utility classes must be safe to call concurrently within a Nextflow session |
+
+---
+
+## 2. Failure Mode Catalogue
+
+| Function | Possible failure | Expected behaviour |
+|----------|-----------------|-------------------|
+| `dumpParametersToJSON` | `outdir` does not exist | Create parent dirs; if creation fails, log warning and continue |
+| `checkCondaChannels` | `conda` binary not on PATH | Return `true` (non-blocking); log debug message |
+| `completionEmail` | SMTP unreachable | Log warning; do not throw; do not crash pipeline |
+| `imNotification` | Slack/Teams webhook misconfigured | Log warning; do not throw |
+| `getReferencesFile` | genome key not found in igenomes map | Throw `AbortOperationException` with a clear message naming the missing key |
+
+---
+
+## 3. Testing for Reliability
+
+- Every failure mode in the catalogue above must have a corresponding Spock test.
+- Use Spock's `thrown()` assertion for expected exceptions.
+- Mock external calls (SMTP, HTTP webhooks, `conda` binary) in tests — do not make network calls in unit tests.
+- Use `@TempDir` or equivalent for file system tests to avoid polluting the build directory.
+
+---
+
+## 4. Observability
+
+The plugin uses Nextflow's built-in `log` (SLF4J) at appropriate levels:
+
+| Level | When to use |
+|-------|-------------|
+| `log.debug` | Verbose internal state useful only for debugging |
+| `log.info` | Normal operational events (pipeline start, completion, version) |
+| `log.warn` | Advisory issues that do not stop the pipeline |
+| `log.error` | Fatal issues immediately before a controlled exit |
+
+Do not use `println` — use `log.*` so output respects the user's Nextflow log configuration.
+
+---
+
+## 5. Compatibility Testing
+
+Before releasing a new version:
+
+1. Test against the **minimum** declared `nextflowVersion` (see `build.gradle`).
+2. Test against the **latest stable** Nextflow release.
+3. If either test fails, do not release until the compatibility issue is resolved or the version floor is updated with a clear CHANGELOG note.
+
+---
+
+## 6. Incident Process
+
+If a released version causes pipeline failures in the wild:
+
+1. Open a GitHub issue immediately with reproducible steps.
+2. Tag the issue `severity:critical` if pipelines cannot run.
+3. Prioritise a patch release over all other work.
+4. Post-fix: add a regression test that would have caught the issue.
+5. Document the incident in the relevant CHANGELOG entry.

--- a/docs/SECURITY.md
+++ b/docs/SECURITY.md
@@ -1,0 +1,66 @@
+# SECURITY.md — Security Posture
+
+> nf-core-utils is a Nextflow plugin library used in bioinformatics pipelines.
+> While it is not a user-facing web service, it processes credentials, file paths,
+> and external service integrations that require a thoughtful security posture.
+
+---
+
+## 1. Threat Model
+
+| Asset | Threat | Mitigation |
+|-------|--------|-----------|
+| SMTP credentials | Leaked into logs or param JSON | Credentials come from `params.email_on_fail`/config, never logged at info/debug; not dumped to JSON |
+| Slack/Teams webhook URLs | Leaked into logs or param JSON | Treat as secrets; never log the full URL |
+| File paths (outdir, references) | Path traversal | Use Nextflow `Path` resolution; do not construct paths via string concatenation with user input |
+| igenomes config | Untrusted genome key | Validate key against known map; fail loudly if not found |
+| External YAML (meta.yml) | Malformed YAML crashing the plugin | SnakeYAML parsing wrapped in try/catch with informative error |
+| Build artifacts | Supply chain attack | Use Gradle wrapper (`./gradlew`); pin dependency versions in `build.gradle` |
+
+---
+
+## 2. Credential Handling Rules
+
+1. **Never** include credentials (SMTP passwords, webhook URLs, API tokens) in:
+   - Log output at any level.
+   - The `params_<timestamp>.json` file produced by `dumpParametersToJSON`.
+   - Exception messages.
+
+2. Credentials must come from Nextflow secrets, environment variables, or `~/.nextflow/config` — not hardcoded in pipeline scripts.
+
+3. If a function receives a credential parameter, document it as a secret in the function's Groovydoc.
+
+---
+
+## 3. Dependency Security
+
+- Minimise runtime dependencies (currently: SnakeYAML only).
+- Before adding a new dependency: check it against known CVE databases.
+- Keep SnakeYAML pinned to a non-vulnerable version; review with each release.
+- Run `./gradlew dependencyCheckAnalyze` (OWASP dependency check) if added to `build.gradle`.
+
+---
+
+## 4. Reporting a Vulnerability
+
+Do **not** open a public GitHub issue for security vulnerabilities.
+
+Contact: security@nf-co.re (or open a [GitHub Security Advisory](https://github.com/nf-core/nf-core-utils/security/advisories/new) if available).
+
+Include:
+- Description of the vulnerability.
+- Steps to reproduce.
+- Potential impact.
+- Suggested fix if known.
+
+We aim to acknowledge reports within 48 hours and publish a fix within 14 days for critical issues.
+
+---
+
+## 5. Security Checklist for PRs
+
+- [ ] No credentials, tokens, or URLs hardcoded or logged.
+- [ ] User-supplied file paths resolved via Nextflow's `Path` API, not string concatenation.
+- [ ] New external inputs (YAML, JSON, config) wrapped in try/catch with sanitised error messages.
+- [ ] New dependencies reviewed for known CVEs.
+- [ ] If SMTP/webhook logic changed: verify credentials are not included in any log statement.

--- a/docs/design-docs/core-beliefs.md
+++ b/docs/design-docs/core-beliefs.md
@@ -1,0 +1,52 @@
+# 001 — Core Beliefs & Design Principles
+
+**Status**: Accepted  
+**Date**: 2025-01  
+**Author(s)**: nf-core-utils team
+
+---
+
+## Context
+
+nf-core-utils exists to provide reliable, community-owned utility functions to nf-core pipelines through Nextflow's plugin system. As the project grows, we need an explicit statement of the values that shape every technical decision — so that autonomous contributors (human or AI) make consistent choices without constant hand-holding.
+
+---
+
+## Core Beliefs
+
+### 1. Simplicity over cleverness
+The plugin is infrastructure that hundreds of pipelines depend on. Surprising behaviour has outsized blast radius. Prefer the obvious implementation; reserve cleverness for places where it provably matters.
+
+### 2. Testability is non-negotiable
+Every public function must be independently testable without a live Nextflow session. This is why extension methods are thin delegates and business logic lives in stateless utility classes.
+
+### 3. The plugin must not surprise its callers
+- **No side effects** beyond what the function name implies.
+- **No silent failures** — throw informative exceptions or return clearly typed results.
+- **Backward compatibility** — existing `@Function` signatures never change without a major version bump.
+
+### 4. Minimal runtime surface
+Adding an external dependency is a tax on every pipeline that loads the plugin. A new dependency requires explicit justification in a design doc and a note in the tech-debt tracker.
+
+Current runtime dependencies: `SnakeYAML` (required for YAML meta.yml parsing).
+
+### 5. Document decisions, not just outcomes
+Code explains *what*. Comments and docs explain *why*. ADRs capture the decision landscape so future contributors don't re-litigate resolved questions.
+
+### 6. nf-core community standards first
+The plugin's purpose is to serve the nf-core ecosystem. When community conventions conflict with local preferences, community conventions win.
+
+---
+
+## Consequences
+
+- New features require at minimum: unit tests + docs entry + CHANGELOG update.
+- Dependency additions require a design doc.
+- Any change to a public `@Function` signature that could break existing callers requires a major version bump and a migration guide entry.
+
+---
+
+## Alternatives Considered
+
+- **Merging utility logic back into subworkflows**: Rejected — subworkflows require copying into each pipeline; plugins are versioned and upgradeable centrally.
+- **Single monolithic utility class**: Rejected — untestable sections would grow; separation by domain (versioning, notifications, reporting, …) keeps concerns isolated.

--- a/docs/design-docs/index.md
+++ b/docs/design-docs/index.md
@@ -1,0 +1,51 @@
+# Design Docs — Index
+
+> This directory contains Architecture Decision Records (ADRs) and design explorations for nf-core-utils.
+> Add a new file here whenever you make a non-trivial architectural choice; link it in the table below.
+
+---
+
+## Active Design Docs
+
+| # | Title | Status | Date |
+|---|-------|--------|------|
+| 001 | [Core Beliefs & Design Principles](core-beliefs.md) | Accepted | 2025-01 |
+
+---
+
+## How to Write a Design Doc
+
+1. Copy the template below into a new file: `docs/design-docs/<NNN>-<short-title>.md`.
+2. Fill in all sections. "Context" and "Decision" are mandatory; others are encouraged.
+3. Add a row to the table above and link to the file.
+4. Design docs are **append-only** — amend by adding a new ADR that supersedes, not by editing the old one.
+
+### Template
+
+```markdown
+# <NNN> — <Title>
+
+**Status**: Proposed | Accepted | Deprecated | Superseded by #NNN  
+**Date**: YYYY-MM-DD  
+**Author(s)**: <name or "team">
+
+## Context
+What forces or constraints led to this decision?
+
+## Decision
+What did we decide?
+
+## Consequences
+What becomes easier? Harder? What must change?
+
+## Alternatives Considered
+What else was evaluated and why was it rejected?
+```
+
+---
+
+## Conventions
+
+- File names: `<NNN>-kebab-title.md` (zero-padded to three digits).
+- Status moves from **Proposed → Accepted** when merged to main.
+- Mark as **Deprecated** when a decision no longer applies; link the superseding doc.

--- a/docs/exec-plans/tech-debt-tracker.md
+++ b/docs/exec-plans/tech-debt-tracker.md
@@ -1,0 +1,32 @@
+# Tech Debt Tracker
+
+> Track known tech debt here. Each item has an ID, a severity, and a link to context.
+> **Severity**: 🔴 Critical · 🟡 High · 🟢 Low  
+> Move resolved items to the "Resolved" section with a date and the PR/commit that fixed it.
+
+---
+
+## Open Items
+
+| ID | Severity | Summary | File(s) | Opened |
+|----|----------|---------|---------|--------|
+| TD-001 | 🟢 Low | No integration test that exercises the plugin against a real Nextflow run in CI | `.github/workflows/` | 2025-01 |
+| TD-002 | 🟢 Low | `docs/generated/db-schema.md` is hand-maintained; should be auto-generated | `docs/generated/` | 2025-01 |
+| TD-003 | 🟡 High | Observer pattern is not covered by dedicated unit tests | `NfcorePipelineObserver.groovy` | 2025-01 |
+
+---
+
+## Resolved Items
+
+| ID | Summary | Resolved | PR/Commit |
+|----|---------|----------|-----------|
+| — | — | — | — |
+
+---
+
+## How to Add a New Item
+
+1. Assign the next available `TD-NNN` ID.
+2. Choose severity honestly: 🔴 if it will cause production failures, 🟡 if it degrades maintainability significantly, 🟢 for low-impact items.
+3. Link to the relevant files or design docs.
+4. If you fix an item, move it to "Resolved" with the date and commit/PR reference — do **not** delete it.

--- a/docs/generated/db-schema.md
+++ b/docs/generated/db-schema.md
@@ -1,0 +1,78 @@
+# Generated: Data / Schema Reference
+
+> **Status**: Hand-maintained stub. See [TD-002](../exec-plans/tech-debt-tracker.md) for the plan to auto-generate this file.
+>
+> nf-core-utils is a stateless plugin — it has no persistent database. This file documents structured data contracts instead (YAML schemas, JSON parameter shapes, and key in-memory data structures).
+
+---
+
+## 1. Pipeline Parameters JSON (`dumpParametersToJSON` output)
+
+**Path**: `<outdir>/pipeline_info/params_<timestamp>.json`
+
+```json
+{
+  "<param_name>": "<value>",
+  "..."
+}
+```
+
+- All keys are taken directly from the Nextflow `params` map at run time.
+- Values are serialised by SnakeYAML / Groovy JSON builder; types are preserved where serialisable.
+- The file is timestamped (`yyyy-MM-dd_HH-mm-ss`) to allow multiple runs in the same output directory.
+
+---
+
+## 2. Versions YAML (MultiQC input)
+
+Produced by `NfcoreVersionUtils`. Consumed by MultiQC for the software-versions table.
+
+```yaml
+# Example shape
+<process_name>:
+  <tool_name>: "<semver>"
+```
+
+---
+
+## 3. Citations / Bibliography (meta.yml contract)
+
+`NfcoreCitationUtils` reads citations from per-module `meta.yml` files. Expected shape:
+
+```yaml
+tools:
+  - <tool_name>:
+      description: "..."
+      homepage: "https://..."
+      documentation: "https://..."
+      doi: "10.xxxx/..."
+      licence: ["MIT"]
+```
+
+Fields `doi` and `licence` are used in the generated bibliography and methods section.
+
+---
+
+## 4. igenomes / References Config
+
+`ReferencesUtils` resolves reference files from parameters matching the igenomes convention:
+
+```
+params.genome    → key into the igenomes map
+params.<file_key> → optional override path
+```
+
+Resolved value is returned as a `Path` or `String` depending on the caller context.
+
+---
+
+## 5. Observer Session State
+
+`NfcorePipelineObserver` holds transient per-session state (not persisted):
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `session` | `Session` | Active Nextflow session reference |
+| Internal counters | `int` | Process-complete event tracking |
+
+State is reset when the observer is re-created for a new session.

--- a/docs/product-specs/index.md
+++ b/docs/product-specs/index.md
@@ -1,0 +1,56 @@
+# Product Specs — Index
+
+> Product specs describe **what** we are building from a user/pipeline-author perspective and **why**.
+> They are distinct from design docs (which describe architectural decisions) and exec plans (which describe *how* to implement something).
+
+---
+
+## Active Specs
+
+| # | Title | Status | Owner |
+|---|-------|--------|-------|
+| PS-001 | [New User Onboarding](new-user-onboarding.md) | Draft | — |
+
+---
+
+## Spec Lifecycle
+
+```
+Draft → Review → Accepted → In Development → Shipped → Archived
+```
+
+- **Draft**: Author is still writing; not ready for implementation.
+- **Review**: Spec is complete; seeking feedback before commit.
+- **Accepted**: Approved for implementation; linked exec plan should exist in `docs/exec-plans/active/`.
+- **Shipped**: Feature is live in a released version.
+- **Archived**: Spec was rejected or superseded.
+
+---
+
+## Template
+
+```markdown
+# PS-NNN — <Feature Name>
+
+**Status**: Draft | Review | Accepted | Shipped | Archived  
+**Version target**: <semver or "TBD">  
+**Author(s)**: <name>
+
+## Problem
+What user pain does this address?
+
+## Goals
+What does success look like?
+
+## Non-Goals
+What is explicitly out of scope?
+
+## User Stories
+- As a pipeline author, I want … so that …
+
+## Acceptance Criteria
+- [ ] Concrete, testable conditions for "done"
+
+## Open Questions
+- Unresolved decisions that need answers before implementation
+```

--- a/docs/product-specs/new-user-onboarding.md
+++ b/docs/product-specs/new-user-onboarding.md
@@ -1,0 +1,57 @@
+# PS-001 — New User Onboarding
+
+**Status**: Draft  
+**Version target**: TBD  
+**Author(s)**: nf-core-utils team
+
+---
+
+## Problem
+
+Pipeline authors who are new to nf-core must currently read multiple scattered documents to understand how to adopt the nf-core-utils plugin. There is no single "getting started" path that:
+
+1. Explains what the plugin provides.
+2. Shows the minimal import to make a pipeline nf-core-compliant.
+3. Validates that the setup is correct before a full pipeline run.
+
+This results in misconfigured plugins, missed features, and community support burden.
+
+---
+
+## Goals
+
+- A new pipeline author can go from zero to a working plugin import in under 10 minutes.
+- The onboarding path is self-serve; no community support needed for the happy path.
+- The plugin surface feels discoverable — authors can find additional features without reading every doc page.
+
+---
+
+## Non-Goals
+
+- This spec does not cover migration from legacy subworkflows (see migration guide in `docs/NextflowPipelineExtension.md`).
+- It does not address CI/CD pipeline configuration or nf-core linting rules.
+
+---
+
+## User Stories
+
+- As a **new pipeline author**, I want a single page that shows me the minimum viable import, so that I can get started without reading all the docs first.
+- As an **existing nf-core contributor**, I want to verify at a glance which plugin version adds a feature I need, so that I can set the correct version constraint.
+- As an **autonomous agent** contributing to a pipeline, I want a machine-readable list of available `@Function` names and their signatures, so that I can construct correct import statements.
+
+---
+
+## Acceptance Criteria
+
+- [ ] A "Quick Start" section exists at the top of `README.md` that shows the minimal import and a working pipeline snippet.
+- [ ] All public `@Function` names are listed in a single reference table (in `docs/` or `ARCHITECTURE.md`) with parameter types and return types.
+- [ ] An automated check (e.g. a `make check-docs` target) verifies that the public function table is not stale relative to `NfUtilsExtension.groovy`.
+- [ ] The onboarding path is validated with a new Spock integration test that runs the "Quick Start" snippet against a mock Nextflow session.
+
+---
+
+## Open Questions
+
+1. Should the quick-start snippet live in `README.md` or in a dedicated `docs/QUICKSTART.md`?
+2. Do we generate the function reference table from source (e.g. via Groovydoc) or maintain it manually?
+3. Should onboarding include a `nf-core-utils validate` CLI command, or is the existing `checkConfigProvided()` function sufficient?

--- a/docs/references/design-system-reference-llms.txt
+++ b/docs/references/design-system-reference-llms.txt
@@ -1,0 +1,50 @@
+# Design System Reference — LLMs.txt
+# Quick-reference for autonomous contributors on UI/doc conventions in nf-core-utils.
+# Format: plain text, structured for LLM consumption.
+
+PROJECT: nf-core-utils (Nextflow plugin)
+LANGUAGE: Groovy / JVM
+DOCS FORMAT: Markdown (GitHub Flavored + MkDocs admonitions where noted)
+
+---
+
+## Documentation Style
+
+- Use imperative present tense in headings: "Validate conda channels" not "Validating conda channels".
+- Code blocks must specify the language tag: ```groovy, ```nextflow, ```bash, ```yaml, ```json.
+- Use MkDocs admonition syntax for callouts: !!! note / !!! tip / !!! warning / !!! danger
+- Tables: always include a header row; align pipes for readability.
+- Cross-links: use relative Markdown links (e.g. `[ARCHITECTURE](../../ARCHITECTURE.md)`).
+
+## Naming Conventions
+
+- Groovy classes: PascalCase, suffix by role:
+    - *Utils    → stateless utility class (e.g. NfcoreVersionUtils)
+    - *Extension → Nextflow extension point (e.g. NfUtilsExtension)
+    - *Observer  → trace observer (e.g. NfcorePipelineObserver)
+    - *Factory   → observer or plugin factory
+- Public @Function methods: camelCase, verb-noun (e.g. getWorkflowVersion, checkCondaChannels).
+- Nextflow params: lowercase with underscores (e.g. params.outdir, params.genome).
+
+## Code Example Conventions
+
+- Always show import statement at top of code block.
+- For multi-function examples, show all imports in one include{} block.
+- Label code blocks with title attribute where context helps: ```nextflow title="main.nf"
+- Show expected console output in a ```console block immediately after the code block.
+
+## Changelog Format
+
+- Section header: ## [X.Y.Z] - YYYY-MM-DD or ## [Unreleased]
+- Sub-sections: ### Added / ### Changed / ### Fixed / ### Removed / ### Deprecated
+- Items: bullet point starting with verb, past tense: "Added support for…"
+
+## File Structure Conventions
+
+- All public API docs: docs/<FeatureName>.md (PascalCase)
+- Utility class docs: docs/utilities/<ClassName>.md
+- Design decisions: docs/design-docs/<NNN>-<kebab-title>.md
+- Exec plans: docs/exec-plans/active/<YYYY-MM>-<kebab-title>.md
+
+---
+# END OF REFERENCE

--- a/docs/references/nixpacks-llms.txt
+++ b/docs/references/nixpacks-llms.txt
@@ -1,0 +1,49 @@
+# Nixpacks Reference — LLMs.txt
+# Quick-reference for autonomous contributors on build/deploy tooling.
+# nf-core-utils is a JVM/Gradle project; Nixpacks is noted here for context
+# if the project ever adopts container-first CI or deployment workflows.
+
+PROJECT: nf-core-utils
+BUILD SYSTEM: Gradle (Groovy DSL) via build.gradle + settings.gradle
+RUNTIME: JVM (Groovy); no persistent server process — this is a Nextflow plugin library
+
+---
+
+## Current Build Toolchain
+
+  Gradle wrapper:   ./gradlew  (do not require global Gradle install)
+  Java target:      JVM 11+ (check build.gradle for sourceCompatibility)
+  Plugin SDK:       io.nextflow.nextflow-plugin (see build.gradle plugins block)
+  Test runner:      Spock Framework (runs via ./gradlew test)
+  Packaging:        ./gradlew assemble → produces ZIP in build/plugins/
+
+## Makefile Shortcuts
+
+  make assemble   → ./gradlew assemble
+  make test       → ./gradlew test
+  make install    → ./gradlew install   (copies plugin to ~/.nextflow/plugins/)
+  make clean      → ./gradlew clean
+  make release    → ./gradlew releasePlugin (needs GitHub creds)
+
+## Container / CI Notes
+
+- There is no application server; the plugin is loaded into a Nextflow JVM process.
+- CI should: (1) cache Gradle dependencies, (2) run `make test`, (3) optionally run
+  a smoke test with `nextflow run hello -plugins nf-core-utils@<version>`.
+- If adopting Nixpacks for CI containers: detect Java, install Gradle wrapper, run
+  `./gradlew assemble test`. No special Nix configuration required beyond a JDK image.
+
+## Dependency Management
+
+- Runtime deps declared in build.gradle `dependencies {}` block.
+- Adding a dep requires: design doc update + tech-debt-tracker note.
+- Current runtime deps: org.yaml:snakeyaml:2.2
+
+## Environment Variables (build time)
+
+  GITHUB_USERNAME        → set in ~/.gradle/gradle.properties for release
+  GITHUB_ACCESS_TOKEN    → set in ~/.gradle/gradle.properties for release
+  GITHUB_COMMIT_EMAIL    → set in ~/.gradle/gradle.properties for release
+
+---
+# END OF REFERENCE

--- a/docs/references/uv-llms.txt
+++ b/docs/references/uv-llms.txt
@@ -1,0 +1,50 @@
+# uv / Python Tooling Reference — LLMs.txt
+# Quick-reference for autonomous contributors.
+# nf-core-utils is a JVM/Groovy project. Python tooling (uv, pre-commit) is used
+# only for developer tooling and linting — NOT for the plugin runtime.
+
+PROJECT: nf-core-utils
+PRIMARY LANGUAGE: Groovy (JVM)
+PYTHON TOOLING ROLE: Dev tooling only (pre-commit hooks, linting, docs generation if added)
+
+---
+
+## pre-commit (Python-based)
+
+Config: .pre-commit-config.yaml (repo root)
+
+Run locally:
+  pre-commit run --all-files    # check everything
+  pre-commit install            # install git hooks
+
+Hooks typically include: trailing whitespace, end-of-file fixer, YAML lint, etc.
+Check .pre-commit-config.yaml for the exact set in use.
+
+## uv (fast Python package manager)
+
+uv is NOT currently a hard dependency of this project. If Python scripts are added
+(e.g. doc generation, schema validators), prefer uv for reproducible Python environments.
+
+Typical usage if adopted:
+  uv venv .venv
+  uv pip install -r requirements.txt   # or: uv sync (with pyproject.toml)
+  source .venv/bin/activate
+
+## nf-core Python CLI (external)
+
+The nf-core community CLI tool (pip install nf-core) provides linting and scaffolding
+for nf-core pipelines. It is EXTERNAL to this plugin repository but relevant context:
+
+  nf-core lint      → validate pipeline against nf-core schema
+  nf-core schema    → manage nextflow_schema.json
+
+This plugin (nf-core-utils) is NOT the same as the nf-core Python CLI.
+
+## Python Version Policy (if scripts are added)
+
+- Minimum: Python 3.11
+- Pin versions in pyproject.toml or requirements.txt using uv lock format.
+- Do not commit .venv/ (already in .gitignore).
+
+---
+# END OF REFERENCE


### PR DESCRIPTION
## Summary

Adds a scaffold of living documentation designed for autonomous contributors (LLM agents, bots, and humans onboarding without hand-holding). No existing files were modified.

## New files

### Root
| File | Purpose |
|------|---------|
| `AGENTS.md` | Autonomous contributor orientation: repo overview, dev workflow, conventions, guardrails |
| `ARCHITECTURE.md` | Layer diagram, package map, key design decisions, data/control flows, build & release reference |

### `docs/` governance
| File | Purpose |
|------|---------|
| `DESIGN.md` | Design philosophy, patterns in use (stateless utils, thin extension, observer), feature checklist |
| `FRONTEND.md` | Public `@Function` API surface — all importable functions with parameter/return types |
| `PLANS.md` | Roadmap index, near-term priorities, exec-plan template |
| `PRODUCT_SENSE.md` | User personas, feature heuristics, decision trees for common choices |
| `QUALITY_SCORE.md` | Quality dimensions with targets, pre-merge checklist, periodic health check |
| `RELIABILITY.md` | Reliability contract, failure-mode catalogue, observability levels, incident process |
| `SECURITY.md` | Threat model, credential handling rules, dependency security, vuln reporting |

### `docs/design-docs/`
- `index.md` — ADR index with template and conventions
- `core-beliefs.md` — ADR-001: core design principles with full rationale

### `docs/exec-plans/`
- `active/` — directory for in-flight plans
- `completed/` — directory for shipped plans
- `tech-debt-tracker.md` — three seed tech-debt items identified during authoring

### `docs/generated/`
- `db-schema.md` — data contracts: params JSON shape, versions YAML, citations meta.yml, references config

### `docs/product-specs/`
- `index.md` — spec lifecycle, index table, template
- `new-user-onboarding.md` — PS-001: onboarding problem statement, goals, user stories, acceptance criteria

### `docs/references/`
- `design-system-reference-llms.txt` — doc style & naming conventions for LLM consumption
- `nixpacks-llms.txt` — build toolchain reference
- `uv-llms.txt` — Python tooling context (pre-commit, uv, nf-core CLI distinction)

## Checklist
- [x] No existing files modified
- [x] All content is specific to the nf-core-utils Groovy/Gradle/Nextflow stack
- [x] `AGENTS.md` clearly states what autonomous contributors must not do
- [x] `docs/exec-plans/active/` and `completed/` are tracked via `.gitkeep`