### PR TITLE
docs: add self-driving documentation scaffold

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,26 @@
+# AGENTS.md
+
+Guide for autonomous contributors (LLMs and humans).
+
+## Mission
+- Keep `nf-core-utils` stable, testable, and backwards compatible.
+- Prefer small, reviewable changes with clear intent.
+
+## Fast Start
+1. Read `README.md`, `CLAUDE.md`, and `ARCHITECTURE.md`.
+2. Check active plans in `docs/exec-plans/active/`.
+3. Run:
+   - `make assemble`
+   - `make test`
+
+## Guardrails
+- Do not break public `@Function` behavior without migration notes.
+- Add/update tests for any functional change.
+- Update docs when behavior or API shape changes.
+- Avoid adding dependencies without documenting rationale in `docs/design-docs/`.
+
+## Definition of Done
+- Code compiles.
+- Relevant tests pass.
+- Changelog/docs updated.
+- Risk notes captured in the matching plan/spec if applicable.

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -1,0 +1,26 @@
+# ARCHITECTURE.md
+
+High-level architecture of `nf-core-utils`.
+
+## System Shape
+- **Plugin layer**: PF4J + Nextflow extension entry points.
+- **Utility layer**: stateless domain utilities (versioning, reporting, notifications, references).
+- **Integration layer**: Nextflow runtime hooks/observers.
+
+## Source Layout
+- `src/main/groovy/nfcore/plugin/` — plugin + extension entry points
+- `src/main/groovy/nfcore/plugin/nfcore/` — nf-core utility modules
+- `src/main/groovy/nfcore/plugin/nextflow/` — Nextflow-specific helpers
+- `src/main/groovy/nfcore/plugin/references/` — reference resolution
+- `src/test/groovy/` — Spock tests
+
+## Architectural Rules
+- Keep extension functions thin; delegate to utility classes.
+- Prefer pure/stateless helpers to simplify tests.
+- Public behavior changes require tests + documentation.
+
+## Related Docs
+- Design rationale: `docs/DESIGN.md`
+- Quality targets: `docs/QUALITY_SCORE.md`
+- Reliability posture: `docs/RELIABILITY.md`
+- Security posture: `docs/SECURITY.md`

--- a/docs/DESIGN.md
+++ b/docs/DESIGN.md
@@ -1,0 +1,13 @@
+# DESIGN.md
+
+Design intent for `nf-core-utils`.
+
+## Goals
+- Reliable reusable utilities for nf-core pipelines.
+- Predictable behavior across plugin versions.
+- Maintainable internals with strong tests.
+
+## Design Tenets
+- Thin extension interface, rich utility modules.
+- Fail clearly; avoid silent fallbacks.
+- Keep dependencies minimal.

--- a/docs/FRONTEND.md
+++ b/docs/FRONTEND.md
@@ -1,0 +1,10 @@
+# FRONTEND.md
+
+This project is primarily a backend/plugin codebase with no standalone frontend app.
+
+## UI Surface
+- User-facing surface is Nextflow pipeline logs, reports, and generated artifacts.
+
+## Guidance
+- Treat output formatting as UX.
+- Keep messages actionable and concise.

--- a/docs/PLANS.md
+++ b/docs/PLANS.md
@@ -1,0 +1,15 @@
+# PLANS.md
+
+Execution planning hub.
+
+## Structure
+- Active plans: `docs/exec-plans/active/`
+- Completed plans: `docs/exec-plans/completed/`
+- Debt inventory: `docs/exec-plans/tech-debt-tracker.md`
+
+## Plan Template
+- Objective
+- Scope / non-scope
+- Milestones
+- Risks and mitigations
+- Validation checklist

--- a/docs/PRODUCT_SENSE.md
+++ b/docs/PRODUCT_SENSE.md
@@ -1,0 +1,11 @@
+# PRODUCT_SENSE.md
+
+How to evaluate product decisions for this plugin.
+
+## North Star
+Make nf-core pipeline utility behavior easier to adopt, safer to run, and simpler to maintain.
+
+## Decision Filters
+- Does this reduce maintainer toil?
+- Does this improve reliability of pipeline execution?
+- Is migration impact explicit and manageable?

--- a/docs/QUALITY_SCORE.md
+++ b/docs/QUALITY_SCORE.md
@@ -1,0 +1,14 @@
+# QUALITY_SCORE.md
+
+Quality rubric for autonomous contributors.
+
+## Scorecard (0-5 each)
+1. Correctness (tests + behavior)
+2. Safety/backward compatibility
+3. Documentation completeness
+4. Simplicity/maintainability
+5. Observability/debuggability
+
+## Minimum Merge Bar
+- No category below 3
+- Average score >= 4 for non-trivial changes

--- a/docs/RELIABILITY.md
+++ b/docs/RELIABILITY.md
@@ -1,0 +1,13 @@
+# RELIABILITY.md
+
+Reliability posture for `nf-core-utils`.
+
+## Priorities
+- Deterministic behavior for utility functions.
+- Clear error paths with actionable messages.
+- Coverage of critical flows with automated tests.
+
+## Reliability Practices
+- Add regression tests for every bug fix.
+- Prefer explicit validation over permissive defaults.
+- Track flaky behavior and remediate quickly.

--- a/docs/SECURITY.md
+++ b/docs/SECURITY.md
@@ -1,0 +1,11 @@
+# SECURITY.md
+
+Security guidance for contributors.
+
+## Baseline Rules
+- Never commit secrets or credentials.
+- Validate/sanitize external inputs where applicable.
+- Keep dependencies minimal and auditable.
+
+## Reporting
+If a vulnerability is discovered, follow project maintainer disclosure guidance and avoid public exploit details before a fix is available.

--- a/docs/design-docs/core-beliefs.md
+++ b/docs/design-docs/core-beliefs.md
@@ -1,0 +1,9 @@
+# Core Beliefs
+
+Principles for self-driving development in this repo.
+
+1. **Stability first** — this plugin supports many pipelines; avoid surprising changes.
+2. **Testability over cleverness** — keep logic modular and easy to verify.
+3. **Backward compatibility matters** — treat public extension behavior as a contract.
+4. **Small changes win** — incremental improvements reduce risk and review friction.
+5. **Document intent** — decisions should be legible to future contributors and agents.

--- a/docs/design-docs/index.md
+++ b/docs/design-docs/index.md
@@ -1,0 +1,11 @@
+# Design Docs Index
+
+Use this folder for ADR-style records of technical decisions.
+
+## Current Docs
+- [Core Beliefs](./core-beliefs.md)
+
+## Add a New Design Doc
+- Filename: `NNN-short-title.md` (e.g. `002-observer-contract.md`)
+- Include: context, decision, alternatives, consequences
+- Link new docs from this index

--- a/docs/exec-plans/tech-debt-tracker.md
+++ b/docs/exec-plans/tech-debt-tracker.md
@@ -1,0 +1,14 @@
+# Tech Debt Tracker
+
+Track debt with IDs so autonomous contributors can plan cleanup safely.
+
+## Open
+| ID | Severity | Debt | Owner | Next Action |
+|---|---|---|---|---|
+| TD-001 | Medium | No automated generation flow for `docs/generated/db-schema.md` | Unassigned | Add generation script + CI check |
+| TD-002 | Medium | Limited integration testing against real Nextflow runtime paths | Unassigned | Add end-to-end smoke coverage |
+
+## Completed
+| ID | Date | Resolution |
+|---|---|---|
+| _none_ | - | - |

--- a/docs/generated/db-schema.md
+++ b/docs/generated/db-schema.md
@@ -1,0 +1,10 @@
+# DB Schema (Generated)
+
+This file is reserved for generated schema/reference output.
+
+## Status
+No DB schema is currently generated for this project.
+
+## Contract
+- Do not edit manually once generation is wired.
+- If generation is added, document source command and CI hook at the top of this file.

--- a/docs/product-specs/index.md
+++ b/docs/product-specs/index.md
@@ -1,0 +1,13 @@
+# Product Specs Index
+
+Product-level behavior specs for the plugin experience.
+
+## Specs
+- [New User Onboarding](./new-user-onboarding.md)
+
+## Spec Template
+- Problem
+- User/persona
+- Success criteria
+- Non-goals
+- Rollout and observability

--- a/docs/product-specs/new-user-onboarding.md
+++ b/docs/product-specs/new-user-onboarding.md
@@ -1,0 +1,21 @@
+# New User Onboarding Spec
+
+## Problem
+New pipeline maintainers need to adopt `nf-core-utils` quickly with low setup friction.
+
+## Target User
+- nf-core pipeline maintainers
+- Contributors migrating from legacy utilities/subworkflows
+
+## Success Criteria
+- User can install/use plugin with documented commands.
+- First successful run includes expected utility behavior.
+- Common errors map to actionable messages.
+
+## Non-goals
+- Redesigning Nextflow plugin UX.
+- Supporting legacy behavior without explicit migration notes.
+
+## Acceptance Signals
+- Setup docs are sufficient for first-run success.
+- Smoke test steps in README/CLAUDE are reproducible.

--- a/docs/references/design-system-reference-llms.txt
+++ b/docs/references/design-system-reference-llms.txt
@@ -1,0 +1,8 @@
+Design System Reference (LLM-facing)
+
+Purpose: quick style and documentation conventions for autonomous contributors.
+
+- Prefer concise markdown with clear headings.
+- Use tables for status trackers and plan indexes.
+- Keep file names stable and predictable.
+- Record rationale (why), not only implementation details (what).

--- a/docs/references/nixpacks-llms.txt
+++ b/docs/references/nixpacks-llms.txt
@@ -1,0 +1,7 @@
+Nixpacks Reference (LLM-facing)
+
+This repository currently uses Gradle/Make-driven workflows.
+If Nixpacks is introduced:
+- capture build/start assumptions here,
+- record env vars,
+- and note cache/runtime expectations for CI/CD agents.

--- a/docs/references/uv-llms.txt
+++ b/docs/references/uv-llms.txt
@@ -1,0 +1,7 @@
+uv Reference (LLM-facing)
+
+`uv` is not a primary tool in this repository today.
+If Python helper tooling is added with `uv`, document:
+- lockfile policy,
+- virtual environment expectations,
+- reproducible command patterns for CI and local runs.


### PR DESCRIPTION
## Summary
Adds a self-driving documentation scaffold to help autonomous/LLM contributors navigate, plan, and execute safely.

## Includes
- Root: `AGENTS.md`, `ARCHITECTURE.md`
- `docs/design-docs/`: index + core beliefs
- `docs/exec-plans/`: active/completed placeholders + tech debt tracker
- `docs/generated/`: db schema placeholder
- `docs/product-specs/`: index + new-user onboarding
- `docs/references/`: LLM-oriented reference stubs
- Operational docs: `DESIGN.md`, `FRONTEND.md`, `PLANS.md`, `PRODUCT_SENSE.md`, `QUALITY_SCORE.md`, `RELIABILITY.md`, `SECURITY.md`

## Notes
- Existing docs were left untouched unless creating the requested exact paths.
- This is starter content intended to be evolved over time.
