### PR TITLE
docs: add nf-core utils release skill

### DIFF
--- a/.agents/skills/nf-core-utils-release/SKILL.md
+++ b/.agents/skills/nf-core-utils-release/SKILL.md
@@ -1,0 +1,172 @@
+---
+name: "nf-core-utils-release"
+description: "Use when the user asks to release, cut, publish, ship, or verify an nf-core/nf-core-utils plugin release. This skill covers the full release path: confirming PR/CI state, preparing a clean worktree, configuring the Nextflow Plugin Registry token safely via the user's global Gradle config, running the Gradle/Make release, creating the matching GitHub release, and verifying GitHub releases against the Nextflow Plugin Registry. Use it even if the user only says 'cut a release' or 'is it on the registry?' while working in nf-core-utils."
+---
+
+# nf-core-utils release
+
+## Purpose
+
+Release `nf-core/nf-core-utils` safely to both:
+
+1. the Nextflow Plugin Registry, and
+2. GitHub Releases.
+
+The release flow is intentionally conservative because it touches public artifacts and secrets. Prefer clean worktrees, explicit verification, and redacted output.
+
+## Before releasing
+
+1. Confirm the target repository and branch.
+   - Expected repo: `nf-core/nf-core-utils`.
+   - Expected release branch: `main`, usually after merging a PR.
+   - If currently in a side worktree or feature branch, do not assume it is safe to release from there.
+2. Check PR/CI state when a PR is involved.
+   - `gh pr view <pr> --json state,mergeStateStatus,statusCheckRollup,mergedAt,mergeCommit,url`
+   - Release only after the PR is merged and required checks are green, unless the user explicitly instructs otherwise.
+3. Check the version in `build.gradle`.
+   - `grep -n "^version" build.gradle`
+   - Confirm it is the intended version and newer than the latest released version.
+4. Check the changelog.
+   - Ensure `CHANGELOG.md` has an entry for the version being released.
+5. Verify the local GitHub CLI context.
+   - `gh auth status`
+   - `gh repo view --json nameWithOwner,url`
+
+## Secret handling
+
+The Nextflow Gradle plugin reads the registry token from `npr.apiKey` or `NPR_API_KEY`, not from the older README example `pluginRegistry.accessToken`.
+
+If the user provides the 1Password reference:
+
+```text
+op://Employee/Nextflow Plugin Registry Token/credential
+```
+
+read it with `op read` and write it only to the user's global Gradle properties file using the bundled helper:
+
+```bash
+TOKEN="$(op read 'op://Employee/Nextflow Plugin Registry Token/credential')"
+python "<path-to-skill>/scripts/configure_registry_token.py" "$TOKEN"
+unset TOKEN
+grep -E 'github_|npr\.apiKey|pluginRegistry' ~/.gradle/gradle.properties | sed 's/=.*/=<redacted>/'
+```
+
+Important:
+- Do not write tokens into the repository.
+- Do not print the token.
+- Redact `~/.gradle/gradle.properties` output.
+- If the user asks where the token went, answer clearly: `~/.gradle/gradle.properties`, not the codebase.
+
+## Recommended release workflow
+
+Use a clean temporary worktree at `origin/main` so local untracked files in the user's normal checkout cannot interfere.
+
+```bash
+git fetch origin main --tags
+rm -rf /tmp/nf-core-utils-release
+git worktree add /tmp/nf-core-utils-release origin/main
+cd /tmp/nf-core-utils-release
+```
+
+Verify the checkout:
+
+```bash
+git status --short
+git log --oneline -3
+grep -n "^version" build.gradle
+```
+
+Build before publishing:
+
+```bash
+./gradlew assemble --no-daemon
+```
+
+Release to the Nextflow Plugin Registry:
+
+```bash
+make release
+```
+
+A successful registry release includes output like:
+
+```text
+Plugin 'nf-core-utils' version X.Y.Z has been successfully released to Nextflow Registry [https://registry.nextflow.io/api]!
+```
+
+If release fails with `HTTP 401`:
+- Check that `~/.gradle/gradle.properties` contains `npr.apiKey=<redacted>`.
+- If only `pluginRegistry.accessToken` is present, add `npr.apiKey`; the Gradle plugin expects `npr.apiKey` or `NPR_API_KEY`.
+- Re-run `make release` from the clean worktree.
+
+## Create the GitHub release
+
+The Nextflow registry release may not create a GitHub release/tag. Check first:
+
+```bash
+gh release list --limit 10
+git tag --list | sort -V | tail -20
+```
+
+If the target version is not present on GitHub, create it from the released commit on `main`. Use changelog notes when available.
+
+```bash
+VERSION="0.5.0"  # replace with build.gradle version
+TARGET_SHA="$(git rev-parse HEAD)"
+python "<path-to-skill>/scripts/extract_release_notes.py" "$VERSION" > "/tmp/release-${VERSION}-notes.md"
+gh release create "$VERSION" --target "$TARGET_SHA" --title "$VERSION" --notes-file "/tmp/release-${VERSION}-notes.md"
+```
+
+If a release already exists, do not overwrite it unless the user explicitly asks.
+
+## Verify all release surfaces
+
+Check GitHub releases:
+
+```bash
+gh release list --limit 20
+```
+
+Check the Nextflow Plugin Registry:
+
+```bash
+python3 - <<'PY'
+import json, urllib.request
+with urllib.request.urlopen('https://registry.nextflow.io/api/v1/plugins/nf-core-utils') as response:
+    data = json.load(response)
+for r in data['plugin']['releases']:
+    print(r['version'], r.get('status'), r.get('date'))
+PY
+```
+
+Compare GitHub and registry versions:
+
+```bash
+python "<path-to-skill>/scripts/compare_release_surfaces.py"
+```
+
+Known historical state after releasing `0.5.0`:
+- GitHub releases: `0.1.0`, `0.2.0`, `0.3.0`, `0.3.1`, `0.4.0`, `0.5.0`
+- Registry releases: `0.2.0`, `0.3.0`, `0.3.1`, `0.4.0`, `0.5.0`
+- `0.1.0` exists on GitHub but not in the registry.
+
+Treat this historical note as a clue, not a source of truth: always query current GitHub and registry state.
+
+## Bundled scripts
+
+- `scripts/configure_registry_token.py` — updates `~/.gradle/gradle.properties` with `npr.apiKey` and a compatibility `pluginRegistry.accessToken`, printing only redacted confirmation.
+- `scripts/extract_release_notes.py` — extracts a version section from `CHANGELOG.md` for GitHub release notes.
+- `scripts/compare_release_surfaces.py` — compares GitHub Releases with the Nextflow Plugin Registry and reports missing versions in either direction.
+
+## Final response checklist
+
+When done, tell the user:
+
+- the version released,
+- whether the Nextflow Plugin Registry release succeeded,
+- the GitHub release URL,
+- the target commit SHA,
+- any known mismatch between GitHub releases and registry releases,
+- where credentials were written, if credentials were touched (`~/.gradle/gradle.properties`, redacted).
+
+Keep the final answer concise and avoid exposing secrets.

--- a/.agents/skills/nf-core-utils-release/SKILL.md
+++ b/.agents/skills/nf-core-utils-release/SKILL.md
@@ -52,6 +52,7 @@ grep -E 'github_|npr\.apiKey|pluginRegistry' ~/.gradle/gradle.properties | sed '
 ```
 
 Important:
+
 - Do not write tokens into the repository.
 - Do not print the token.
 - Redact `~/.gradle/gradle.properties` output.
@@ -95,6 +96,7 @@ Plugin 'nf-core-utils' version X.Y.Z has been successfully released to Nextflow 
 ```
 
 If release fails with `HTTP 401`:
+
 - Check that `~/.gradle/gradle.properties` contains `npr.apiKey=<redacted>`.
 - If only `pluginRegistry.accessToken` is present, add `npr.apiKey`; the Gradle plugin expects `npr.apiKey` or `NPR_API_KEY`.
 - Re-run `make release` from the clean worktree.
@@ -146,6 +148,7 @@ python "<path-to-skill>/scripts/compare_release_surfaces.py"
 ```
 
 Known historical state after releasing `0.5.0`:
+
 - GitHub releases: `0.1.0`, `0.2.0`, `0.3.0`, `0.3.1`, `0.4.0`, `0.5.0`
 - Registry releases: `0.2.0`, `0.3.0`, `0.3.1`, `0.4.0`, `0.5.0`
 - `0.1.0` exists on GitHub but not in the registry.

--- a/.agents/skills/nf-core-utils-release/evals/evals.json
+++ b/.agents/skills/nf-core-utils-release/evals/evals.json
@@ -1,0 +1,23 @@
+{
+  "skill_name": "nf-core-utils-release",
+  "evals": [
+    {
+      "id": 1,
+      "prompt": "PR #41 is merged and CI is green. Please cut the nf-core-utils release that is already versioned in build.gradle and publish it everywhere it needs to go.",
+      "expected_output": "Confirms the version, releases from a clean origin/main worktree to the Nextflow Plugin Registry, creates or verifies the matching GitHub release, and reports final URLs/status without leaking credentials.",
+      "files": []
+    },
+    {
+      "id": 2,
+      "prompt": "The release failed with HTTP 401 from https://registry.nextflow.io/api/v1/plugins/release. I have the token in 1Password at op://Employee/Nextflow Plugin Registry Token/credential — fix the auth and retry.",
+      "expected_output": "Reads the token via op, writes it only to ~/.gradle/gradle.properties as npr.apiKey with redacted confirmation, retries make release, and explains that the token was not written into the repo.",
+      "files": []
+    },
+    {
+      "id": 3,
+      "prompt": "Can you check whether every nf-core-utils GitHub release has also been pushed to the Nextflow plugin registry?",
+      "expected_output": "Queries GitHub releases and the registry API, compares version sets, and reports missing versions in either direction. Mentions known historical 0.1.0 mismatch only if confirmed by current queries.",
+      "files": []
+    }
+  ]
+}

--- a/.agents/skills/nf-core-utils-release/scripts/compare_release_surfaces.py
+++ b/.agents/skills/nf-core-utils-release/scripts/compare_release_surfaces.py
@@ -1,0 +1,19 @@
+#!/usr/bin/env python3
+"""Compare nf-core-utils versions on GitHub Releases and the Nextflow Plugin Registry."""
+import json
+import subprocess
+import urllib.request
+
+PLUGIN = "nf-core-utils"
+REGISTRY_URL = f"https://registry.nextflow.io/api/v1/plugins/{PLUGIN}"
+
+release_lines = subprocess.check_output(["gh", "release", "list", "--limit", "50"], text=True).splitlines()
+github_versions = [line.split("\t")[2] for line in release_lines if line.strip()]
+with urllib.request.urlopen(REGISTRY_URL) as response:
+    registry_data = json.load(response)
+registry_versions = [release["version"] for release in registry_data["plugin"]["releases"]]
+
+print("GitHub:", ", ".join(github_versions) or "none")
+print("Registry:", ", ".join(registry_versions) or "none")
+print("Missing from registry:", ", ".join(sorted(set(github_versions) - set(registry_versions))) or "none")
+print("Missing from GitHub:", ", ".join(sorted(set(registry_versions) - set(github_versions))) or "none")

--- a/.agents/skills/nf-core-utils-release/scripts/configure_registry_token.py
+++ b/.agents/skills/nf-core-utils-release/scripts/configure_registry_token.py
@@ -1,0 +1,39 @@
+#!/usr/bin/env python3
+"""Write the Nextflow Plugin Registry token to the user's global Gradle config.
+
+Usage:
+  TOKEN="$(op read 'op://Employee/Nextflow Plugin Registry Token/credential')"
+  python configure_registry_token.py "$TOKEN"
+"""
+from pathlib import Path
+import sys
+
+if len(sys.argv) != 2 or not sys.argv[1].strip():
+    raise SystemExit("usage: configure_registry_token.py <token>")
+
+token = sys.argv[1].strip()
+path = Path.home() / ".gradle" / "gradle.properties"
+keys = {
+    "npr.apiKey": token,
+    # Compatibility with older local notes; Gradle release uses npr.apiKey.
+    "pluginRegistry.accessToken": token,
+}
+lines = path.read_text().splitlines() if path.exists() else []
+seen = set()
+out = []
+for line in lines:
+    matched = False
+    for key, value in keys.items():
+        if line.startswith(key + "="):
+            out.append(f"{key}={value}")
+            seen.add(key)
+            matched = True
+            break
+    if not matched:
+        out.append(line)
+for key, value in keys.items():
+    if key not in seen:
+        out.append(f"{key}={value}")
+path.parent.mkdir(parents=True, exist_ok=True)
+path.write_text("\n".join(out) + "\n")
+print(f"Updated {path} with npr.apiKey=<redacted> and pluginRegistry.accessToken=<redacted>")

--- a/.agents/skills/nf-core-utils-release/scripts/extract_release_notes.py
+++ b/.agents/skills/nf-core-utils-release/scripts/extract_release_notes.py
@@ -1,0 +1,16 @@
+#!/usr/bin/env python3
+"""Extract a version section from CHANGELOG.md."""
+from pathlib import Path
+import argparse
+
+parser = argparse.ArgumentParser()
+parser.add_argument("version", help="release version, e.g. 0.5.0")
+parser.add_argument("--changelog", default="CHANGELOG.md")
+args = parser.parse_args()
+
+text = Path(args.changelog).read_text()
+heading = f"## [{args.version}]"
+start = text.index(heading)
+next_heading = text.find("\n## [", start + len(heading))
+section = text[start:] if next_heading == -1 else text[start:next_heading]
+print(section.strip())

--- a/validation/notification-system/main.nf
+++ b/validation/notification-system/main.nf
@@ -67,9 +67,7 @@ workflow {
             ],
         ]
 
-        def mock_multiqc_reports = [
-            './results/multiqc/multiqc_report.html'
-        ]
+        def mock_multiqc_reports = ['./results/multiqc/multiqc_report.html']
 
         // Test 1: completionSummary() function
         log.info("=== Testing completionSummary() function ===")

--- a/validation/pipeline-utilities/nextflow.config
+++ b/validation/pipeline-utilities/nextflow.config
@@ -132,9 +132,7 @@ validation {
     strictMode      = true
 
     // Expected output files
-    expectedOutputs = [
-        'params.json'
-    ]
+    expectedOutputs = ['params.json']
 }
 
 // Cleanup configuration

--- a/validation/software-versions/main.nf
+++ b/validation/software-versions/main.nf
@@ -24,7 +24,7 @@ workflow {
     // Test 1: YAML strings (legacy format)
     log.info("=== Test 1: YAML strings ===")
 
-    def yaml_strings = Channel.of(
+    def yaml_strings = channel.of(
         'fastqc: 0.12.1',
         'samtools: 1.17',
         'multiqc: 1.15',
@@ -42,7 +42,7 @@ workflow {
     // Test 2: Topic tuples
     log.info("=== Test 2: Topic tuples ===")
 
-    def topic_tuples = Channel.of(
+    def topic_tuples = channel.of(
         ['NFCORE_FASTQC', 'fastqc', '0.12.1'],
         ['NFCORE_SAMTOOLS', 'samtools', '1.17'],
     )
@@ -59,7 +59,7 @@ workflow {
     // Test 3: Mixed inputs
     log.info("=== Test 3: Mixed input types ===")
 
-    def mixed_inputs = Channel.of(
+    def mixed_inputs = channel.of(
         'fastqc: 0.12.1',
         ['NFCORE_SAMTOOLS', 'samtools', '1.17'],
         [multiqc: '1.15', bcftools: '1.16'],
@@ -78,7 +78,7 @@ workflow {
     // Test 4: Custom Nextflow version
     log.info("=== Test 4: Custom Nextflow version ===")
 
-    def versions_ch = Channel.of('fastqc: 0.12.1')
+    def versions_ch = channel.of('fastqc: 0.12.1')
 
     def result4 = softwareVersionsToYAML(
         softwareVersions: versions_ch,
@@ -93,7 +93,7 @@ workflow {
     // Test 5: Named parameters
     log.info("=== Test 5: Named parameters ===")
 
-    def versions_ch5 = Channel.of('samtools: 1.17')
+    def versions_ch5 = channel.of('samtools: 1.17')
 
     def result5 = softwareVersionsToYAML(
         softwareVersions: versions_ch5,
@@ -117,8 +117,7 @@ workflow {
         samtools: 1.17
     """.stripIndent()
 
-    def version_file = Channel
-        .of(version_file_content)
+    def version_file = channel.of(version_file_content)
         .collectFile(name: 'versions.yml', newLine: true)
 
     def result6 = softwareVersionsToYAML(version_file)
@@ -132,7 +131,7 @@ workflow {
     // Test 7: Process name extraction from full path
     log.info("=== Test 7: Process name extraction ===")
 
-    def full_path_tuples = Channel.of(
+    def full_path_tuples = channel.of(
         ['NFCORE_RNASEQ:TRIMGALORE:FASTQC', 'fastqc', '0.12.1']
     )
 
@@ -148,7 +147,7 @@ workflow {
     // Test 8: Sorted output
     log.info("=== Test 8: Alphabetical sorting ===")
 
-    def unsorted = Channel.of(
+    def unsorted = channel.of(
         ['ZEBRA_PROCESS', 'zebra', '1.0.0'],
         ['ALPHA_PROCESS', 'alpha', '2.0.0'],
         ['ALPHA_PROCESS', 'zulu', '3.0.0'],

--- a/validation/topic-channel-citations/main.nf
+++ b/validation/topic-channel-citations/main.nf
@@ -36,7 +36,7 @@ workflow {
     )
 
     // Create sample data
-    samples = Channel.of('sample1', 'sample2', 'sample3')
+    samples = channel.of('sample1', 'sample2', 'sample3')
 
     // Run processes - each automatically emits citations to topic channel
     fastqc_out = FASTQC(samples)

--- a/validation/version-topic-channels/nextflow.config
+++ b/validation/version-topic-channels/nextflow.config
@@ -90,9 +90,7 @@ validation {
     strictMode      = true
 
     // Expected output files
-    expectedOutputs = [
-        'nf_core_utils_software_mqc_versions.yml'
-    ]
+    expectedOutputs = ['nf_core_utils_software_mqc_versions.yml']
 }
 
 // Cleanup configuration


### PR DESCRIPTION
## Summary\n- add a repo-local skill for releasing nf-core-utils to the Nextflow Plugin Registry and GitHub Releases\n- include helper scripts for registry token configuration, changelog release notes, and GitHub/registry comparison\n- include draft eval prompts for release, auth retry, and registry verification workflows\n\n## Validation\n- parsed SKILL.md frontmatter shape\n- validated eval JSON\n- compiled bundled Python scripts\n- ran git diff --check