### PR TITLE
feat: citations on the fly — versions-topic-driven tool citations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- Added `citationsOnTheFly()` and `toolsFromVersionsTopic()` to build tool citations from the `versions` topic (the tools that actually ran), resolved from module `meta.yml` — no per-module changes or hand-maintained tool list ([#43](https://github.com/nf-core/nf-core-utils/pull/43)).
 - Added a `PipelineExecutionContext` seam and focused validation, version, and reporting adapters to keep Nextflow extension functions thin.
 - Added `SoftwareVersionReport` as the canonical implementation for merging heterogeneous software-version inputs.
 - Added `ReferenceSelection` for genome/reference lookup and `igenomes_base` substitution.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
-- Added `citationsOnTheFly()` and `toolsFromVersionsTopic()` to build tool citations from the `versions` topic (the tools that actually ran), resolved from module `meta.yml` — no per-module changes or hand-maintained tool list. Short citations are publication-ready, `tool (version, Author et al. year)`, with graceful fallback to DOI/url ([#43](https://github.com/nf-core/nf-core-utils/pull/43)).
+- Added `citationsOnTheFly()` and `toolsFromVersionsTopic()` to build tool citations from the `versions` topic (the tools that actually ran), resolved from module `meta.yml` — no per-module changes or hand-maintained tool list. Short citations are publication-ready, `tool (version, Author et al. year)`, with graceful fallback to DOI/url. Tools that never emit a version (e.g. MultiQC plugins like `multiqcsav`) can be added manually via `extraTools` ([#43](https://github.com/nf-core/nf-core-utils/pull/43)).
 - Added a `PipelineExecutionContext` seam and focused validation, version, and reporting adapters to keep Nextflow extension functions thin.
 - Added `SoftwareVersionReport` as the canonical implementation for merging heterogeneous software-version inputs.
 - Added `ReferenceSelection` for genome/reference lookup and `igenomes_base` substitution.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
-- Added `citationsOnTheFly()` and `toolsFromVersionsTopic()` to build tool citations from the `versions` topic (the tools that actually ran), resolved from module `meta.yml` — no per-module changes or hand-maintained tool list ([#43](https://github.com/nf-core/nf-core-utils/pull/43)).
+- Added `citationsOnTheFly()` and `toolsFromVersionsTopic()` to build tool citations from the `versions` topic (the tools that actually ran), resolved from module `meta.yml` — no per-module changes or hand-maintained tool list. Short citations are publication-ready, `tool (version, Author et al. year)`, with graceful fallback to DOI/url ([#43](https://github.com/nf-core/nf-core-utils/pull/43)).
 - Added a `PipelineExecutionContext` seam and focused validation, version, and reporting adapters to keep Nextflow extension functions thin.
 - Added `SoftwareVersionReport` as the canonical implementation for merging heterogeneous software-version inputs.
 - Added `ReferenceSelection` for genome/reference lookup and `igenomes_base` substitution.

--- a/docs/NfCoreUtilities.md
+++ b/docs/NfCoreUtilities.md
@@ -116,7 +116,7 @@ include {
 
 // Advanced features for comprehensive pipelines
 include {
-    getCitation; autoToolCitationText;
+    citationsOnTheFly; getCitation; autoToolCitationText;
     generateComprehensiveReport
 } from 'plugin/nf-core-utils'
 ```

--- a/docs/NfCoreUtilities.md
+++ b/docs/NfCoreUtilities.md
@@ -208,9 +208,33 @@ workflow {
 
 Citation management comes in two flavors: modern topic-channel based (recommended) and legacy file-based approaches.
 
-#### Modern Topic Channel Citations (Recommended)
+#### Citations on the Fly (Recommended)
 
-These functions work with the new topic channel citation system:
+The lowest-friction option: derive citations from the tools that actually ran (the `versions` topic every nf-core module already emits) and resolve their metadata from each module's `meta.yml`. No per-module changes, no hand-maintained tool list.
+
+| Function                                            | Purpose                                                | Usage Context       |
+| --------------------------------------------------- | ------------------------------------------------------ | ------------------- |
+| `toolsFromVersionsTopic(topicVersions)`             | Tool names that actually ran, from the `versions` data | Workflow completion |
+| `citationsOnTheFly(topicVersions, metaFilePaths)`   | Citations for only the tools that ran, from `meta.yml` | Workflow completion |
+
+```nextflow title="Citations on the fly"
+include { citationsOnTheFly; methodsDescriptionText } from 'plugin/nf-core-utils'
+
+def meta_yml_paths = files("${projectDir}/modules/**/meta.yml").collect { it.toString() }
+
+ch_methods_description = channel.topic('versions')
+    .collect(flat: false)
+    .map { versions ->
+        def citations = citationsOnTheFly(versions, meta_yml_paths)
+        methodsDescriptionText("${projectDir}/assets/methods_description_template.yml", citations, [:])
+    }
+```
+
+See [NfcoreCitationUtils](utilities/NfcoreCitationUtils.md#citations-on-the-fly-recommended) for the full walkthrough. The descriptive alias `citationsForToolsUsed(...)` is also available.
+
+#### Modern Topic Channel Citations
+
+These functions work with a dedicated `citation` topic that each module emits to:
 
 | Function                                   | Purpose                                        | Usage Context        |
 | ------------------------------------------ | ---------------------------------------------- | -------------------- |

--- a/docs/NfCoreUtilities.md
+++ b/docs/NfCoreUtilities.md
@@ -212,10 +212,10 @@ Citation management comes in two flavors: modern topic-channel based (recommende
 
 The lowest-friction option: derive citations from the tools that actually ran (the `versions` topic every nf-core module already emits) and resolve their metadata from each module's `meta.yml`. No per-module changes, no hand-maintained tool list.
 
-| Function                                            | Purpose                                                | Usage Context       |
-| --------------------------------------------------- | ------------------------------------------------------ | ------------------- |
-| `toolsFromVersionsTopic(topicVersions)`             | Tool names that actually ran, from the `versions` data | Workflow completion |
-| `citationsOnTheFly(topicVersions, metaFilePaths)`   | Citations for only the tools that ran, from `meta.yml` | Workflow completion |
+| Function                                          | Purpose                                                | Usage Context       |
+| ------------------------------------------------- | ------------------------------------------------------ | ------------------- |
+| `toolsFromVersionsTopic(topicVersions)`           | Tool names that actually ran, from the `versions` data | Workflow completion |
+| `citationsOnTheFly(topicVersions, metaFilePaths)` | Citations for only the tools that ran, from `meta.yml` | Workflow completion |
 
 ```nextflow title="Citations on the fly"
 include { citationsOnTheFly; methodsDescriptionText } from 'plugin/nf-core-utils'

--- a/docs/NfCoreUtilities.md
+++ b/docs/NfCoreUtilities.md
@@ -230,7 +230,7 @@ ch_methods_description = channel.topic('versions')
     }
 ```
 
-See [NfcoreCitationUtils](utilities/NfcoreCitationUtils.md#citations-on-the-fly-recommended) for the full walkthrough. The descriptive alias `citationsForToolsUsed(...)` is also available.
+See [NfcoreCitationUtils](utilities/NfcoreCitationUtils.md#citations-on-the-fly-recommended) for the full walkthrough.
 
 #### Modern Topic Channel Citations
 

--- a/docs/utilities/NfcoreCitationUtils.md
+++ b/docs/utilities/NfcoreCitationUtils.md
@@ -44,7 +44,7 @@ Map citationsOnTheFly(List topicVersions, List<String> metaFilePaths)
 
 **Parameters:**
 
-- `topicVersions` (List): Collected `versions` topic data — `[process, tool, version]` tuples. Collect with `.collect(flat: false)` so the tuples are preserved (plain `.collect()` flattens them).
+- `topicVersions` (List): Collected `versions` topic data — `[process, tool, version]` tuples. Collect with `.collect(flat: false)` so the tuples are preserved (plain `.collect()` flattens them, and the function logs a warning if it receives flattened data).
 - `metaFilePaths` (List<String>): Paths to module `meta.yml` files to resolve citation metadata from.
 
 **Returns:**

--- a/docs/utilities/NfcoreCitationUtils.md
+++ b/docs/utilities/NfcoreCitationUtils.md
@@ -34,7 +34,7 @@ Two functions cover the flow:
 #### `citationsOnTheFly(List topicVersions, List<String> metaFilePaths)`
 
 **Description:**
-Builds a citations map for **only the tools that ran**, by intersecting the `versions` topic (what executed) with citations parsed from the supplied `meta.yml` files (the citation source). The returned map plugs directly into `toolCitationText()`, `toolBibliographyText()`, and `methodsDescriptionText()`. A descriptive alias, `citationsForToolsUsed(...)`, is also available.
+Builds a citations map for **only the tools that ran**, by intersecting the `versions` topic (what executed) with citations parsed from the supplied `meta.yml` files (the citation source). The returned map plugs directly into `toolCitationText()`, `toolBibliographyText()`, and `methodsDescriptionText()`.
 
 **Function Signature:**
 

--- a/docs/utilities/NfcoreCitationUtils.md
+++ b/docs/utilities/NfcoreCitationUtils.md
@@ -57,6 +57,7 @@ Map citationsOnTheFly(List topicVersions, List<String> metaFilePaths)
 
 - `topicVersions` (List): Collected `versions` topic data — `[process, tool, version]` tuples. Collect with `.collect(flat: false)` so the tuples are preserved (plain `.collect()` flattens them, and the function logs a warning if it receives flattened data).
 - `metaFilePaths` (List<String>): Paths to module `meta.yml` files to resolve citation metadata from.
+- `extraTools` (List<String>, optional): Tool names to cite even though they never emit a version — e.g. a MultiQC plugin like `multiqcsav`. They're resolved from `meta.yml` like everything else (with no version segment), so you can still add a tool by hand: `citationsOnTheFly(versions, meta_yml_paths, ['multiqcsav'])`.
 
 **Returns:**
 

--- a/docs/utilities/NfcoreCitationUtils.md
+++ b/docs/utilities/NfcoreCitationUtils.md
@@ -18,6 +18,128 @@ This migration strategy ensures backward compatibility while enabling pipelines 
 
 ## Available Functions
 
+### Citations on the Fly (Recommended)
+
+The lowest-friction way to make citations reflect the tools a pipeline actually ran — generated _on the fly_ from the run itself, not from a hand-maintained list. It requires **no per-module changes**: every nf-core module already emits a `[process, tool, version]` tuple to the `versions` topic when it executes, so that topic _is_ the list of tools that ran. These functions intersect that list with citation metadata parsed from each module's `meta.yml`, so only tools that actually executed are cited.
+
+Two functions cover the flow:
+
+| Function                                                   | Purpose                                                 | When to call          |
+| ---------------------------------------------------------- | ------------------------------------------------------- | --------------------- |
+| `toolsFromVersionsTopic(topicVersions)`                    | Reduce collected `versions` data to the tool names used | Workflow completion   |
+| `citationsOnTheFly(topicVersions, metaFilePaths)`          | Citations for only the tools that ran, from `meta.yml`  | Workflow completion   |
+
+---
+
+#### `citationsOnTheFly(List topicVersions, List<String> metaFilePaths)`
+
+**Description:**
+Builds a citations map for **only the tools that ran**, by intersecting the `versions` topic (what executed) with citations parsed from the supplied `meta.yml` files (the citation source). The returned map plugs directly into `toolCitationText()`, `toolBibliographyText()`, and `methodsDescriptionText()`. A descriptive alias, `citationsForToolsUsed(...)`, is also available.
+
+**Function Signature:**
+
+```nextflow
+Map citationsOnTheFly(List topicVersions, List<String> metaFilePaths)
+```
+
+**Parameters:**
+
+- `topicVersions` (List): Collected `versions` topic data — `[process, tool, version]` tuples. Collect with `.collect(flat: false)` so the tuples are preserved (plain `.collect()` flattens them).
+- `metaFilePaths` (List<String>): Paths to module `meta.yml` files to resolve citation metadata from.
+
+**Returns:**
+
+- `Map`: Citations keyed by tool name (`[citation: ..., bibliography: ...]`), restricted to tools that ran.
+
+!!! note "Tool-name matching"
+
+    Tool names from the `versions` topic are matched against `meta.yml` tool keys **exactly first, then case-insensitively** (so `FastQC` lines up with `fastqc`). A tool that ran but has no matching `meta.yml` citation entry is logged as a warning — add it to that module's `meta.yml` `tools:` section to silence it.
+
+**Pipeline Integration (`utils_nfcore_<pipeline>_pipeline/main.nf`):**
+
+This is the reproducible replacement for a hand-maintained `toolReferencesMap` and a static `toolCitationText()` / `toolBibliographyText()`. Wire it into the methods-description channel:
+
+```nextflow title="subworkflows/local/utils_nfcore_<pipeline>_pipeline/main.nf"
+include { citationsOnTheFly; methodsDescriptionText } from 'plugin/nf-core-utils'
+
+// Resolve every module meta.yml once (citation metadata source).
+// files() returns an empty list when nothing matches the glob.
+def meta_yml_paths = files("${projectDir}/modules/**/meta.yml").collect { it.toString() }
+
+ch_methods_description = channel.topic('versions')   // every module emits here when it runs
+    .collect(flat: false)                            // flat: false keeps each [process, tool, version] tuple
+    .map { topic_versions ->
+        // Citations for ONLY the tools that ran, resolved from meta.yml
+        def citations = citationsOnTheFly(topic_versions, meta_yml_paths)
+        methodsDescriptionText(
+            "${projectDir}/assets/methods_description_template.yml",
+            citations,
+            [:]
+        )
+    }
+
+ch_multiqc_files = ch_multiqc_files.mix(
+    ch_methods_description.collectFile(name: 'methods_description_mqc.yaml', sort: true)
+)
+```
+
+**Before / After:**
+
+```nextflow title="Before — static, hand-maintained"
+// Every tool listed by hand; cited even if it never ran
+def citation_text = [
+    "Tools used in the workflow included:",
+    "BWAMEM2 (Vasimuddin et al. 2019)",
+    "FastQC (Andrews 2010),",
+    // ...one line per tool, forever...
+].join(' ').trim()
+```
+
+```nextflow title="After — citations on the fly, zero maintenance"
+// Cites exactly the tools that ran, metadata from each module's meta.yml
+def citations = citationsOnTheFly(topic_versions, meta_yml_paths)
+def citation_text = toolCitationText(citations)
+```
+
+---
+
+#### `toolsFromVersionsTopic(List topicVersions)`
+
+**Description:**
+Extracts the unique, sorted set of tool names that actually executed from collected `versions` topic data. Useful on its own (e.g. for conditional logic) or as the selection input to `filterCitationsByTools()`.
+
+**Function Signature:**
+
+```nextflow
+List<String> toolsFromVersionsTopic(List topicVersions)
+```
+
+**Parameters:**
+
+- `topicVersions` (List): Collected `versions` topic data — `[process, tool, version]` tuples (collect with `.collect(flat: false)`).
+
+**Returns:**
+
+- `List<String>`: Sorted, de-duplicated tool names. Empty list for `null`/empty input.
+
+**Usage Example:**
+
+```nextflow
+include { toolsFromVersionsTopic } from 'plugin/nf-core-utils'
+
+channel.topic('versions').collect(flat: false).map { versions ->
+    def tools = toolsFromVersionsTopic(versions)
+    log.info "Tools that ran: ${tools.join(', ')}"
+    // e.g. "Tools that ran: fastqc, multiqc, samtools"
+}
+```
+
+!!! tip "meta.yml vs. the `citation` topic"
+
+    `citationsOnTheFly()` keeps the citation source as canonical `meta.yml` files while gating by what ran — no need to add `getCitation(...)` emissions to every module. If you have already migrated modules to emit a dedicated `citation` topic, the [`getCitation` + `autoToolCitationText`](#getcitationstring-metaymlpath) path below is equivalent and needs no `meta.yml` paths.
+
+---
+
 ### Modern Approach Functions (Recommended)
 
 ### `getCitation(String metaYmlPath)`

--- a/docs/utilities/NfcoreCitationUtils.md
+++ b/docs/utilities/NfcoreCitationUtils.md
@@ -106,7 +106,7 @@ def citation_text = toolCitationText(citations)
 #### `toolsFromVersionsTopic(List topicVersions)`
 
 **Description:**
-Extracts the unique, sorted set of tool names that actually executed from collected `versions` topic data. Useful on its own (e.g. for conditional logic) or as the selection input to `filterCitationsByTools()`.
+Extracts the unique, sorted set of tool names that actually executed from collected `versions` topic data. Useful on its own — e.g. for conditional logic like `if ('star' in tools)`. (`citationsOnTheFly()` uses it internally to select which citations to emit.)
 
 **Function Signature:**
 

--- a/docs/utilities/NfcoreCitationUtils.md
+++ b/docs/utilities/NfcoreCitationUtils.md
@@ -24,10 +24,10 @@ The lowest-friction way to make citations reflect the tools a pipeline actually 
 
 Two functions cover the flow:
 
-| Function                                                   | Purpose                                                 | When to call          |
-| ---------------------------------------------------------- | ------------------------------------------------------- | --------------------- |
-| `toolsFromVersionsTopic(topicVersions)`                    | Reduce collected `versions` data to the tool names used | Workflow completion   |
-| `citationsOnTheFly(topicVersions, metaFilePaths)`          | Citations for only the tools that ran, from `meta.yml`  | Workflow completion   |
+| Function                                          | Purpose                                                 | When to call        |
+| ------------------------------------------------- | ------------------------------------------------------- | ------------------- |
+| `toolsFromVersionsTopic(topicVersions)`           | Reduce collected `versions` data to the tool names used | Workflow completion |
+| `citationsOnTheFly(topicVersions, metaFilePaths)` | Citations for only the tools that ran, from `meta.yml`  | Workflow completion |
 
 ---
 

--- a/docs/utilities/NfcoreCitationUtils.md
+++ b/docs/utilities/NfcoreCitationUtils.md
@@ -36,6 +36,17 @@ Two functions cover the flow:
 **Description:**
 Builds a citations map for **only the tools that ran**, by intersecting the `versions` topic (what executed) with citations parsed from the supplied `meta.yml` files (the citation source). The returned map plugs directly into `toolCitationText()`, `toolBibliographyText()`, and `methodsDescriptionText()`.
 
+Each **short citation** is formatted for direct copy-paste into a methods paragraph — `tool (version, Author et al. year)` — with the version taken from the `versions` topic and the author/year from `meta.yml`. The reference segment degrades gracefully: short author + year → `doi: …` → homepage url → description. So richer `meta.yml` files produce richer citations:
+
+| `meta.yml` fields present   | Short citation                                       |
+| --------------------------- | ---------------------------------------------------- |
+| `author`, `year`            | `fastqc (0.12.1, Andrews 2010)`                      |
+| `author` (multiple), `year` | `samtools (1.21, Danecek et al. 2021)`               |
+| `doi` only                  | `multiqc (1.21, doi: 10.1093/bioinformatics/btw354)` |
+| `homepage` only             | `seqtk (1.4, https://github.com/lh3/seqtk)`          |
+
+The full `bibliography` entry (author, year, title, journal, doi, url) is unchanged.
+
 **Function Signature:**
 
 ```nextflow

--- a/src/main/groovy/nfcore/plugin/NfUtilsExtension.groovy
+++ b/src/main/groovy/nfcore/plugin/NfUtilsExtension.groovy
@@ -553,6 +553,48 @@ class NfUtilsExtension extends PluginExtensionPoint {
     }
 
     /**
+     * Extract the unique set of tool names that actually ran, from collected
+     * 'versions' topic data ([process, tool, version] tuples).
+     *
+     * @param topicVersions Versions-topic data, e.g. channel.topic('versions').collect()
+     * @return Sorted, de-duplicated list of tool names
+     */
+    @Function
+    List<String> toolsFromVersionsTopic(List topicVersions) {
+        return NfcoreCitationUtils.toolsFromVersionsTopic(topicVersions)
+    }
+
+    /**
+     * Citations on the fly: build citations for only the tools that ran,
+     * resolved from module meta.yml.
+     *
+     * Intersects the 'versions' topic (what executed) with citations parsed from
+     * the supplied meta.yml files. The returned map feeds directly into
+     * {@link #toolCitationText}, {@link #toolBibliographyText} and
+     * {@link #methodsDescriptionText}.
+     *
+     * @param topicVersions Versions-topic data, e.g. channel.topic('versions').collect()
+     * @param metaFilePaths Paths to module meta.yml files
+     * @return Citations map (tool -> [citation, bibliography]) for tools that ran
+     */
+    @Function
+    Map citationsOnTheFly(List topicVersions, List<String> metaFilePaths) {
+        return NfcoreCitationUtils.citationsOnTheFly(topicVersions, metaFilePaths)
+    }
+
+    /**
+     * Descriptive alias for {@link #citationsOnTheFly}.
+     *
+     * @param topicVersions Versions-topic data, e.g. channel.topic('versions').collect()
+     * @param metaFilePaths Paths to module meta.yml files
+     * @return Citations map (tool -> [citation, bibliography]) for tools that ran
+     */
+    @Function
+    Map citationsForToolsUsed(List topicVersions, List<String> metaFilePaths) {
+        return NfcoreCitationUtils.citationsOnTheFly(topicVersions, metaFilePaths)
+    }
+
+    /**
      * Generate workflow summary for MultiQC
      * @param summaryParams Map of parameter groups and their parameters
      * @return YAML formatted string for MultiQC

--- a/src/main/groovy/nfcore/plugin/NfUtilsExtension.groovy
+++ b/src/main/groovy/nfcore/plugin/NfUtilsExtension.groovy
@@ -573,13 +573,14 @@ class NfUtilsExtension extends PluginExtensionPoint {
      * {@link #toolCitationText}, {@link #toolBibliographyText} and
      * {@link #methodsDescriptionText}.
      *
-     * @param topicVersions Versions-topic data, e.g. channel.topic('versions').collect()
+     * @param topicVersions Versions-topic data, e.g. channel.topic('versions').collect(flat: false)
      * @param metaFilePaths Paths to module meta.yml files
+     * @param extraTools Extra tool names to cite even though they did not emit a version (e.g. multiqcsav)
      * @return Citations map (tool -> [citation, bibliography]) for tools that ran
      */
     @Function
-    Map citationsOnTheFly(List topicVersions, List<String> metaFilePaths) {
-        return NfcoreCitationUtils.citationsOnTheFly(topicVersions, metaFilePaths)
+    Map citationsOnTheFly(List topicVersions, List<String> metaFilePaths, List<String> extraTools = []) {
+        return NfcoreCitationUtils.citationsOnTheFly(topicVersions, metaFilePaths, extraTools)
     }
 
     /**

--- a/src/main/groovy/nfcore/plugin/NfUtilsExtension.groovy
+++ b/src/main/groovy/nfcore/plugin/NfUtilsExtension.groovy
@@ -583,18 +583,6 @@ class NfUtilsExtension extends PluginExtensionPoint {
     }
 
     /**
-     * Descriptive alias for {@link #citationsOnTheFly}.
-     *
-     * @param topicVersions Versions-topic data, e.g. channel.topic('versions').collect()
-     * @param metaFilePaths Paths to module meta.yml files
-     * @return Citations map (tool -> [citation, bibliography]) for tools that ran
-     */
-    @Function
-    Map citationsForToolsUsed(List topicVersions, List<String> metaFilePaths) {
-        return NfcoreCitationUtils.citationsOnTheFly(topicVersions, metaFilePaths)
-    }
-
-    /**
      * Generate workflow summary for MultiQC
      * @param summaryParams Map of parameter groups and their parameters
      * @return YAML formatted string for MultiQC

--- a/src/main/groovy/nfcore/plugin/nfcore/NfcoreCitationUtils.groovy
+++ b/src/main/groovy/nfcore/plugin/nfcore/NfcoreCitationUtils.groovy
@@ -553,12 +553,17 @@ class NfcoreCitationUtils {
      * {@link #toolCitationText}, {@link #toolBibliographyText} and
      * {@link #methodsDescriptionText}.
      *
+     * {@code extraTools} lets you add tools that never emit to the versions topic
+     * (e.g. a MultiQC plugin like {@code multiqcsav}); they are resolved from
+     * meta.yml just like the rest, with no version segment.
+     *
      * @param topicVersions Collected 'versions' topic data ([process, tool, version] tuples)
      * @param metaFilePaths Paths to module meta.yml files
+     * @param extraTools Extra tool names to cite even though they did not emit a version
      * @return Citations map (tool -> [citation, bibliography]) for tools that ran
      */
-    static Map citationsOnTheFly(List topicVersions, List<String> metaFilePaths) {
-        def toolsUsed = toolsFromVersionsTopic(topicVersions)
+    static Map citationsOnTheFly(List topicVersions, List<String> metaFilePaths, List<String> extraTools = []) {
+        def toolsUsed = (toolsFromVersionsTopic(topicVersions) + (extraTools ?: [])).unique().sort()
         def versionByLower = toolVersionsFromTopic(topicVersions)
             .collectEntries { tool, ver -> [tool.toString().toLowerCase(), ver] }
         def toolInfo = collectToolInfo(metaFilePaths)

--- a/src/main/groovy/nfcore/plugin/nfcore/NfcoreCitationUtils.groovy
+++ b/src/main/groovy/nfcore/plugin/nfcore/NfcoreCitationUtils.groovy
@@ -473,15 +473,36 @@ class NfcoreCitationUtils {
     }
 
     /**
-     * Reduce a citations map to only the tools that actually ran.
+     * Map each tool that ran to its version, from collected 'versions' topic data.
+     *
+     * Keeps the first version seen per tool (tool names preserved as emitted).
+     *
+     * @param topicVersions Collected 'versions' topic data ([process, tool, version] tuples)
+     * @return Map of tool name -> version (never null)
+     */
+    static Map toolVersionsFromTopic(List topicVersions) {
+        def versions = [:]
+        topicVersions?.each { entry ->
+            if (entry instanceof List && entry.size() >= 3 && entry[1] != null) {
+                def tool = entry[1].toString().trim()
+                def ver = entry[2]?.toString()?.trim()
+                if (tool && ver && !versions.containsKey(tool)) versions[tool] = ver
+            }
+        }
+        return versions
+    }
+
+    /**
+     * Reduce a name-keyed map to only the tools that actually ran.
      *
      * Matching is exact first, then case-insensitive, so versions-topic names
      * (e.g. "FastQC") line up with meta.yml tool keys (e.g. "fastqc"). Tools that
-     * ran but have no citation entry are logged so authors can add them.
+     * ran but have no entry are logged so authors can add them. Value-agnostic:
+     * works on formatted-citation maps or raw meta.yml info maps alike.
      *
-     * @param allCitations Citations keyed by tool name (from meta.yml parsing)
+     * @param allCitations Map keyed by tool name (formatted citations or raw info)
      * @param toolsUsed Tool names that executed (e.g. from {@link #toolsFromVersionsTopic})
-     * @return Citations map containing only entries for tools that ran
+     * @return Subset of {@code allCitations} for the tools that ran
      */
     static Map filterCitationsByTools(Map allCitations, List<String> toolsUsed) {
         if (!allCitations || !toolsUsed) return [:]
@@ -501,12 +522,35 @@ class NfcoreCitationUtils {
     }
 
     /**
+     * Build a publication-style short citation for a single tool:
+     * {@code tool (version, Author et al. year)}.
+     *
+     * The reference segment is the short author + year when meta.yml provides
+     * them, otherwise it falls back to {@code doi: ...}, then the homepage url,
+     * then the description. The version segment is omitted when unknown.
+     *
+     * @param tool Tool name (display)
+     * @param info Raw meta.yml tool info (author, year, doi, homepage, description)
+     * @param version Tool version (optional)
+     * @return Short citation string suitable for a methods paragraph
+     */
+    static String formatShortCitation(String tool, Map info, String version = null) {
+        def parts = []
+        if (version) parts << version
+        def ref = shortReference(info ?: [:])
+        if (ref) parts << ref
+        return parts ? "${tool} (${parts.join(', ')})" : tool.toString()
+    }
+
+    /**
      * Citations on the fly: build citations for ONLY the tools that ran,
      * resolved from module meta.yml.
      *
      * Intersects the 'versions' topic (what executed) with citations parsed from
-     * the supplied meta.yml files (the citation source). The result plugs directly
-     * into {@link #toolCitationText}, {@link #toolBibliographyText} and
+     * the supplied meta.yml files (the citation source). Each short citation is
+     * formatted as {@code tool (version, Author et al. year)} — version from the
+     * topic, author/year/doi/url from meta.yml. The result plugs directly into
+     * {@link #toolCitationText}, {@link #toolBibliographyText} and
      * {@link #methodsDescriptionText}.
      *
      * @param topicVersions Collected 'versions' topic data ([process, tool, version] tuples)
@@ -515,7 +559,61 @@ class NfcoreCitationUtils {
      */
     static Map citationsOnTheFly(List topicVersions, List<String> metaFilePaths) {
         def toolsUsed = toolsFromVersionsTopic(topicVersions)
-        def allCitations = processCitationsFromFile(metaFilePaths)
-        return filterCitationsByTools(allCitations, toolsUsed)
+        def versionByLower = toolVersionsFromTopic(topicVersions)
+            .collectEntries { tool, ver -> [tool.toString().toLowerCase(), ver] }
+        def toolInfo = collectToolInfo(metaFilePaths)
+        def selected = filterCitationsByTools(toolInfo, toolsUsed)
+
+        return selected.collectEntries { tool, info ->
+            def version = versionByLower[tool.toString().toLowerCase()]
+            [(tool): [
+                citation    : formatShortCitation(tool.toString(), info as Map, version),
+                bibliography: formatBibliographyFromData(tool.toString(), info as Map)
+            ]]
+        }
+    }
+
+    /**
+     * Collect raw meta.yml tool info keyed by tool name, reusing {@link #getCitation}
+     * for parsing (handles missing/malformed files gracefully).
+     */
+    private static Map collectToolInfo(List<String> metaFilePaths) {
+        def info = [:]
+        metaFilePaths?.each { path ->
+            getCitation(path).each { tuple ->
+                if (tuple.size() >= 3 && tuple[2] instanceof Map && !info.containsKey(tuple[1])) {
+                    info[tuple[1]] = tuple[2]
+                }
+            }
+        }
+        return info
+    }
+
+    /**
+     * Short reference for the inline citation: "Surname et al. year" when an
+     * author is known, else "doi: ...", else the homepage url, else description.
+     */
+    private static String shortReference(Map info) {
+        def author = info.author?.toString()?.trim()
+        if (author) {
+            def year = info.year ? info.year.toString().trim() : ''
+            def sa = shortAuthor(author)
+            return year ? "${sa} ${year}" : sa
+        }
+        if (info.doi) return "doi: ${info.doi}"
+        if (info.homepage) return info.homepage.toString()
+        return info.description ? info.description.toString() : ''
+    }
+
+    /**
+     * Reduce an author string to "Surname" (single author) or "Surname et al."
+     * (multiple). Heuristic: first author is the text before the first comma;
+     * its surname is the first whitespace-delimited token.
+     */
+    private static String shortAuthor(String author) {
+        def first = author.split(',')[0].trim()
+        def surname = first.split(/\s+/)[0]
+        def multiple = author.contains(',') || author.toLowerCase().contains('et al')
+        return multiple ? "${surname} et al." : surname
     }
 }

--- a/src/main/groovy/nfcore/plugin/nfcore/NfcoreCitationUtils.groovy
+++ b/src/main/groovy/nfcore/plugin/nfcore/NfcoreCitationUtils.groovy
@@ -464,19 +464,12 @@ class NfcoreCitationUtils {
      */
     static List<String> toolsFromVersionsTopic(List topicVersions) {
         if (!topicVersions) return []
-        def tools = [] as LinkedHashSet
-        def sawTuple = false
-        topicVersions.each { entry ->
-            if (entry instanceof List && entry.size() >= 2) {
-                sawTuple = true
-                def tool = entry[1]?.toString()?.trim()
-                if (tool) tools << tool
-            }
-        }
-        if (!sawTuple) {
+        def tuples = topicVersions.findAll { it instanceof List && it.size() >= 2 }
+        if (tuples.isEmpty()) {
             log.warn("toolsFromVersionsTopic received ${topicVersions.size()} item(s) but no [process, tool, version] tuples — collect the versions topic with .collect(flat: false) to preserve tuples")
+            return []
         }
-        return tools.toList().sort()
+        return tuples.collect { it[1]?.toString()?.trim() }.findAll { it }.unique().sort()
     }
 
     /**
@@ -493,12 +486,11 @@ class NfcoreCitationUtils {
     static Map filterCitationsByTools(Map allCitations, List<String> toolsUsed) {
         if (!allCitations || !toolsUsed) return [:]
 
-        def lowerIndex = [:]
-        allCitations.each { name, _entry -> lowerIndex[name.toString().toLowerCase()] = name }
+        def byLowerName = allCitations.collectEntries { name, _entry -> [name.toString().toLowerCase(), name] }
 
         def selected = [:]
         toolsUsed.each { tool ->
-            def key = allCitations.containsKey(tool) ? tool : lowerIndex[tool.toString().toLowerCase()]
+            def key = allCitations.containsKey(tool) ? tool : byLowerName[tool.toString().toLowerCase()]
             if (key != null) {
                 selected[key] = allCitations[key]
             } else {
@@ -525,16 +517,5 @@ class NfcoreCitationUtils {
         def toolsUsed = toolsFromVersionsTopic(topicVersions)
         def allCitations = processCitationsFromFile(metaFilePaths)
         return filterCitationsByTools(allCitations, toolsUsed)
-    }
-
-    /**
-     * Descriptive alias for {@link #citationsOnTheFly}.
-     *
-     * @param topicVersions Collected 'versions' topic data ([process, tool, version] tuples)
-     * @param metaFilePaths Paths to module meta.yml files
-     * @return Citations map (tool -> [citation, bibliography]) for tools that ran
-     */
-    static Map citationsForToolsUsed(List topicVersions, List<String> metaFilePaths) {
-        return citationsOnTheFly(topicVersions, metaFilePaths)
     }
 }

--- a/src/main/groovy/nfcore/plugin/nfcore/NfcoreCitationUtils.groovy
+++ b/src/main/groovy/nfcore/plugin/nfcore/NfcoreCitationUtils.groovy
@@ -456,7 +456,8 @@ class NfcoreCitationUtils {
      * 'versions' topic when it runs, so this yields the tools used in a run with
      * no per-module changes — the basis for citations that match what ran.
      *
-     * Robust to the extra nesting that channel.collect() can introduce.
+     * Expects each entry to be a [process, tool, version] tuple, i.e. the topic
+     * collected with {@code .collect(flat: false)}.
      *
      * @param topicVersions Collected 'versions' topic data ([process, tool, version] tuples)
      * @return Sorted, de-duplicated list of tool names (never null)
@@ -464,9 +465,9 @@ class NfcoreCitationUtils {
     static List<String> toolsFromVersionsTopic(List topicVersions) {
         if (!topicVersions) return []
         def tools = [] as LinkedHashSet
-        flattenVersionTuples(topicVersions).each { tuple ->
-            if (tuple.size() >= 2 && tuple[1] != null) {
-                def tool = tuple[1].toString().trim()
+        topicVersions.each { entry ->
+            if (entry instanceof List && entry.size() >= 2 && entry[1] != null) {
+                def tool = entry[1].toString().trim()
                 if (tool) tools << tool
             }
         }
@@ -530,27 +531,5 @@ class NfcoreCitationUtils {
      */
     static Map citationsForToolsUsed(List topicVersions, List<String> metaFilePaths) {
         return citationsOnTheFly(topicVersions, metaFilePaths)
-    }
-
-    /**
-     * Flatten 'versions' topic data into a flat list of [process, tool, version]
-     * tuples. A tuple is identified by a non-list first element (the process
-     * name); a list-of-lists is treated as a container and recursed into.
-     *
-     * @param data Raw versions-topic data, possibly nested
-     * @return Flat list of version tuples
-     */
-    private static List<List> flattenVersionTuples(List data) {
-        def out = []
-        data.each { item ->
-            if (item instanceof List) {
-                if (!item.isEmpty() && item[0] instanceof List) {
-                    out.addAll(flattenVersionTuples(item))
-                } else if (item.size() >= 2) {
-                    out << item
-                }
-            }
-        }
-        return out
     }
 }

--- a/src/main/groovy/nfcore/plugin/nfcore/NfcoreCitationUtils.groovy
+++ b/src/main/groovy/nfcore/plugin/nfcore/NfcoreCitationUtils.groovy
@@ -445,4 +445,112 @@ class NfcoreCitationUtils {
         def processedCitations = processCitationsFromTopic(allCitations)
         return toolBibliographyText(processedCitations)
     }
+
+    // --- Versions-topic-driven citations (automatic, runtime-accurate) ---
+
+    /**
+     * Extract the unique set of tool names that actually executed, from
+     * collected 'versions' topic data.
+     *
+     * Every nf-core module already emits [process, tool, version] tuples to the
+     * 'versions' topic when it runs, so this yields the tools used in a run with
+     * no per-module changes — the basis for citations that match what ran.
+     *
+     * Robust to the extra nesting that channel.collect() can introduce.
+     *
+     * @param topicVersions Collected 'versions' topic data ([process, tool, version] tuples)
+     * @return Sorted, de-duplicated list of tool names (never null)
+     */
+    static List<String> toolsFromVersionsTopic(List topicVersions) {
+        if (!topicVersions) return []
+        def tools = [] as LinkedHashSet
+        flattenVersionTuples(topicVersions).each { tuple ->
+            if (tuple.size() >= 2 && tuple[1] != null) {
+                def tool = tuple[1].toString().trim()
+                if (tool) tools << tool
+            }
+        }
+        return tools.toList().sort()
+    }
+
+    /**
+     * Reduce a citations map to only the tools that actually ran.
+     *
+     * Matching is exact first, then case-insensitive, so versions-topic names
+     * (e.g. "FastQC") line up with meta.yml tool keys (e.g. "fastqc"). Tools that
+     * ran but have no citation entry are logged so authors can add them.
+     *
+     * @param allCitations Citations keyed by tool name (from meta.yml parsing)
+     * @param toolsUsed Tool names that executed (e.g. from {@link #toolsFromVersionsTopic})
+     * @return Citations map containing only entries for tools that ran
+     */
+    static Map filterCitationsByTools(Map allCitations, List<String> toolsUsed) {
+        if (!allCitations || !toolsUsed) return [:]
+
+        def lowerIndex = [:]
+        allCitations.each { name, _entry -> lowerIndex[name.toString().toLowerCase()] = name }
+
+        def selected = [:]
+        toolsUsed.each { tool ->
+            def key = allCitations.containsKey(tool) ? tool : lowerIndex[tool.toString().toLowerCase()]
+            if (key != null) {
+                selected[key] = allCitations[key]
+            } else {
+                log.warn("No citation metadata found for tool '${tool}' — add it to the module's meta.yml 'tools:' section")
+            }
+        }
+        return selected
+    }
+
+    /**
+     * Citations on the fly: build citations for ONLY the tools that ran,
+     * resolved from module meta.yml.
+     *
+     * Intersects the 'versions' topic (what executed) with citations parsed from
+     * the supplied meta.yml files (the citation source). The result plugs directly
+     * into {@link #toolCitationText}, {@link #toolBibliographyText} and
+     * {@link #methodsDescriptionText}.
+     *
+     * @param topicVersions Collected 'versions' topic data ([process, tool, version] tuples)
+     * @param metaFilePaths Paths to module meta.yml files
+     * @return Citations map (tool -> [citation, bibliography]) for tools that ran
+     */
+    static Map citationsOnTheFly(List topicVersions, List<String> metaFilePaths) {
+        def toolsUsed = toolsFromVersionsTopic(topicVersions)
+        def allCitations = processCitationsFromFile(metaFilePaths)
+        return filterCitationsByTools(allCitations, toolsUsed)
+    }
+
+    /**
+     * Descriptive alias for {@link #citationsOnTheFly}.
+     *
+     * @param topicVersions Collected 'versions' topic data ([process, tool, version] tuples)
+     * @param metaFilePaths Paths to module meta.yml files
+     * @return Citations map (tool -> [citation, bibliography]) for tools that ran
+     */
+    static Map citationsForToolsUsed(List topicVersions, List<String> metaFilePaths) {
+        return citationsOnTheFly(topicVersions, metaFilePaths)
+    }
+
+    /**
+     * Flatten 'versions' topic data into a flat list of [process, tool, version]
+     * tuples. A tuple is identified by a non-list first element (the process
+     * name); a list-of-lists is treated as a container and recursed into.
+     *
+     * @param data Raw versions-topic data, possibly nested
+     * @return Flat list of version tuples
+     */
+    private static List<List> flattenVersionTuples(List data) {
+        def out = []
+        data.each { item ->
+            if (item instanceof List) {
+                if (!item.isEmpty() && item[0] instanceof List) {
+                    out.addAll(flattenVersionTuples(item))
+                } else if (item.size() >= 2) {
+                    out << item
+                }
+            }
+        }
+        return out
+    }
 }

--- a/src/main/groovy/nfcore/plugin/nfcore/NfcoreCitationUtils.groovy
+++ b/src/main/groovy/nfcore/plugin/nfcore/NfcoreCitationUtils.groovy
@@ -465,11 +465,16 @@ class NfcoreCitationUtils {
     static List<String> toolsFromVersionsTopic(List topicVersions) {
         if (!topicVersions) return []
         def tools = [] as LinkedHashSet
+        def sawTuple = false
         topicVersions.each { entry ->
-            if (entry instanceof List && entry.size() >= 2 && entry[1] != null) {
-                def tool = entry[1].toString().trim()
+            if (entry instanceof List && entry.size() >= 2) {
+                sawTuple = true
+                def tool = entry[1]?.toString()?.trim()
                 if (tool) tools << tool
             }
+        }
+        if (!sawTuple) {
+            log.warn("toolsFromVersionsTopic received ${topicVersions.size()} item(s) but no [process, tool, version] tuples — collect the versions topic with .collect(flat: false) to preserve tuples")
         }
         return tools.toList().sort()
     }

--- a/src/test/groovy/nfcore/plugin/nfcore/NfcoreCitationUtilsTest.groovy
+++ b/src/test/groovy/nfcore/plugin/nfcore/NfcoreCitationUtilsTest.groovy
@@ -1,8 +1,12 @@
 package nfcore.plugin.nfcore
 
+import ch.qos.logback.classic.Logger
+import ch.qos.logback.classic.spi.ILoggingEvent
+import ch.qos.logback.core.read.ListAppender
 import nextflow.Session
 import nextflow.config.Manifest
 import nfcore.plugin.nfcore.NfcoreCitationUtils
+import org.slf4j.LoggerFactory
 import spock.lang.PendingFeature
 import spock.lang.Specification
 import spock.lang.TempDir
@@ -829,6 +833,36 @@ ${tool_bibliography}
         NfcoreCitationUtils.toolsFromVersionsTopic(flattened) == []
     }
 
+    def "toolsFromVersionsTopic warns when given a flattened (non-tuple) versions list"() {
+        given:
+        def appender = captureLogsFor(NfcoreCitationUtils)
+        def flattened = ['NFCORE_FASTQC:FASTQC', 'fastqc', '0.12.1']
+
+        when:
+        def result = NfcoreCitationUtils.toolsFromVersionsTopic(flattened)
+
+        then:
+        result == []
+        logMessages(appender).any { it.contains('flat: false') }
+
+        cleanup:
+        detachAppender(appender)
+    }
+
+    def "toolsFromVersionsTopic does not warn for properly collected tuples"() {
+        given:
+        def appender = captureLogsFor(NfcoreCitationUtils)
+
+        when:
+        NfcoreCitationUtils.toolsFromVersionsTopic([['PROC', 'fastqc', '0.12.1']])
+
+        then:
+        logMessages(appender).every { !it.contains('flat: false') }
+
+        cleanup:
+        detachAppender(appender)
+    }
+
     def "filterCitationsByTools keeps only tools that ran, matching case-insensitively"() {
         given:
         def allCitations = [
@@ -897,6 +931,24 @@ ${tool_bibliography}
 
         and: 'the descriptive alias delegates to the same behaviour'
         NfcoreCitationUtils.citationsForToolsUsed(topicVersions, metaPaths) == result
+    }
+
+    // --- log capture helpers ---
+
+    private ListAppender<ILoggingEvent> captureLogsFor(Class clazz) {
+        def appender = new ListAppender<ILoggingEvent>()
+        def logger = (Logger) LoggerFactory.getLogger(clazz)
+        appender.start()
+        logger.addAppender(appender)
+        return appender
+    }
+
+    private List<String> logMessages(ListAppender<ILoggingEvent> appender) {
+        appender.list.collect { it.formattedMessage }
+    }
+
+    private void detachAppender(ListAppender<ILoggingEvent> appender) {
+        ((Logger) LoggerFactory.getLogger(NfcoreCitationUtils)).detachAppender(appender)
     }
 
     // Helper method to create mock meta.yml files for testing

--- a/src/test/groovy/nfcore/plugin/nfcore/NfcoreCitationUtilsTest.groovy
+++ b/src/test/groovy/nfcore/plugin/nfcore/NfcoreCitationUtilsTest.groovy
@@ -839,6 +839,16 @@ ${tool_bibliography}
         NfcoreCitationUtils.toolsFromVersionsTopic(null) == []
     }
 
+    def "toolsFromVersionsTopic returns empty for a flattened versions list"() {
+        given:
+        // Plain channel.topic('versions').collect() flattens tuples into loose
+        // scalars; only .collect(flat: false) preserves [process, tool, version].
+        def flattened = ['NFCORE_FASTQC:FASTQC', 'fastqc', '0.12.1', 'NFCORE_PIPELINE:MULTIQC', 'multiqc', '1.21']
+
+        expect:
+        NfcoreCitationUtils.toolsFromVersionsTopic(flattened) == []
+    }
+
     def "filterCitationsByTools keeps only tools that ran, matching case-insensitively"() {
         given:
         def allCitations = [
@@ -855,6 +865,22 @@ ${tool_bibliography}
         then:
         result.keySet() == ['fastqc', 'samtools'] as Set
         !result.containsKey('multiqc')
+    }
+
+    def "filterCitationsByTools omits tools that ran but have no citation entry"() {
+        given:
+        def allCitations = [
+            'fastqc': [citation: 'fastqc (...)', bibliography: '<li>FastQC</li>']
+        ]
+        // mysterytool ran but has no meta.yml citation entry
+        def toolsUsed = ['fastqc', 'mysterytool']
+
+        when:
+        def result = NfcoreCitationUtils.filterCitationsByTools(allCitations, toolsUsed)
+
+        then:
+        result.keySet() == ['fastqc'] as Set
+        !result.containsKey('mysterytool')
     }
 
     def "citationsOnTheFly intersects versions topic with meta.yml citations"() {

--- a/src/test/groovy/nfcore/plugin/nfcore/NfcoreCitationUtilsTest.groovy
+++ b/src/test/groovy/nfcore/plugin/nfcore/NfcoreCitationUtilsTest.groovy
@@ -813,26 +813,6 @@ ${tool_bibliography}
         result == ['fastqc', 'multiqc']
     }
 
-    def "toolsFromVersionsTopic handles nested collected structures"() {
-        given:
-        // channel.topic('versions').collect() can hand back nested tuple lists
-        def nested = [
-            [
-                ['PROC_A', 'samtools', '1.21'],
-                ['PROC_B', 'bwa', '0.7.18']
-            ],
-            [
-                ['PROC_C', 'multiqc', '1.21']
-            ]
-        ]
-
-        when:
-        def result = NfcoreCitationUtils.toolsFromVersionsTopic(nested)
-
-        then:
-        result == ['bwa', 'multiqc', 'samtools']
-    }
-
     def "toolsFromVersionsTopic handles empty and null input"() {
         expect:
         NfcoreCitationUtils.toolsFromVersionsTopic([]) == []

--- a/src/test/groovy/nfcore/plugin/nfcore/NfcoreCitationUtilsTest.groovy
+++ b/src/test/groovy/nfcore/plugin/nfcore/NfcoreCitationUtilsTest.groovy
@@ -990,6 +990,39 @@ ${tool_bibliography}
         result.fastqc.bibliography.contains('Andrews S')
     }
 
+    def "citationsOnTheFly can manually add a tool not in the versions topic"() {
+        given:
+        // multiqcsav is a MultiQC plugin: it has a meta.yml but never emits a version
+        def multiqcsavMeta = new File(tempDir.toFile(), 'multiqcsav_meta.yml')
+        multiqcsavMeta << '''
+        name: multiqcsav
+        tools:
+          - multiqcsav:
+              description: "MultiQC plugin for Illumina Sequencing Analysis Viewer"
+              homepage: "https://github.com/MultiQC/MultiQC_SAV/"
+        '''.stripIndent()
+        def fastqcMeta = new File(tempDir.toFile(), 'fastqc_meta.yml')
+        fastqcMeta << '''
+        name: fastqc
+        tools:
+          - fastqc:
+              doi: "10.1093/bioinformatics/btv033"
+        '''.stripIndent()
+        def topicVersions = [['NFCORE:FASTQC', 'fastqc', '0.12.1']]
+
+        when:
+        def result = NfcoreCitationUtils.citationsOnTheFly(
+            topicVersions,
+            [fastqcMeta.absolutePath, multiqcsavMeta.absolutePath],
+            ['multiqcsav']
+        )
+
+        then: 'the manually-added tool is cited (no version segment, resolved from meta.yml)'
+        result.containsKey('fastqc')
+        result.containsKey('multiqcsav')
+        result.multiqcsav.citation == 'multiqcsav (https://github.com/MultiQC/MultiQC_SAV/)'
+    }
+
     // --- log capture helpers ---
 
     private ListAppender<ILoggingEvent> captureLogsFor(Class clazz) {

--- a/src/test/groovy/nfcore/plugin/nfcore/NfcoreCitationUtilsTest.groovy
+++ b/src/test/groovy/nfcore/plugin/nfcore/NfcoreCitationUtilsTest.groovy
@@ -928,9 +928,6 @@ ${tool_bibliography}
         result.containsKey('fastqc')
         !result.containsKey('samtools') // present in meta.yml but did not run
         result.fastqc.citation.contains('fastqc')
-
-        and: 'the descriptive alias delegates to the same behaviour'
-        NfcoreCitationUtils.citationsForToolsUsed(topicVersions, metaPaths) == result
     }
 
     // --- log capture helpers ---

--- a/src/test/groovy/nfcore/plugin/nfcore/NfcoreCitationUtilsTest.groovy
+++ b/src/test/groovy/nfcore/plugin/nfcore/NfcoreCitationUtilsTest.groovy
@@ -796,6 +796,103 @@ ${tool_bibliography}
         bibliography.split('<li>').size() > 3  // Should have multiple bibliography entries
     }
 
+    // --- Versions-topic-driven citations (automatic, runtime-accurate) ---
+
+    def "toolsFromVersionsTopic extracts unique sorted tool names from versions tuples"() {
+        given:
+        def topicVersions = [
+            ['NFCORE_FASTQC:FASTQC', 'fastqc', '0.12.1'],
+            ['NFCORE_PIPELINE:MULTIQC', 'multiqc', '1.21'],
+            ['NFCORE_FASTQC:FASTQC', 'fastqc', '0.12.1'] // duplicate process/tool
+        ]
+
+        when:
+        def result = NfcoreCitationUtils.toolsFromVersionsTopic(topicVersions)
+
+        then:
+        result == ['fastqc', 'multiqc']
+    }
+
+    def "toolsFromVersionsTopic handles nested collected structures"() {
+        given:
+        // channel.topic('versions').collect() can hand back nested tuple lists
+        def nested = [
+            [
+                ['PROC_A', 'samtools', '1.21'],
+                ['PROC_B', 'bwa', '0.7.18']
+            ],
+            [
+                ['PROC_C', 'multiqc', '1.21']
+            ]
+        ]
+
+        when:
+        def result = NfcoreCitationUtils.toolsFromVersionsTopic(nested)
+
+        then:
+        result == ['bwa', 'multiqc', 'samtools']
+    }
+
+    def "toolsFromVersionsTopic handles empty and null input"() {
+        expect:
+        NfcoreCitationUtils.toolsFromVersionsTopic([]) == []
+        NfcoreCitationUtils.toolsFromVersionsTopic(null) == []
+    }
+
+    def "filterCitationsByTools keeps only tools that ran, matching case-insensitively"() {
+        given:
+        def allCitations = [
+            'fastqc'  : [citation: 'fastqc (...)', bibliography: '<li>FastQC</li>'],
+            'multiqc' : [citation: 'multiqc (...)', bibliography: '<li>MultiQC</li>'],
+            'samtools': [citation: 'samtools (...)', bibliography: '<li>SAMtools</li>']
+        ]
+        // multiqc did not run; FastQC differs from the meta.yml key only in case
+        def toolsUsed = ['FastQC', 'samtools']
+
+        when:
+        def result = NfcoreCitationUtils.filterCitationsByTools(allCitations, toolsUsed)
+
+        then:
+        result.keySet() == ['fastqc', 'samtools'] as Set
+        !result.containsKey('multiqc')
+    }
+
+    def "citationsOnTheFly intersects versions topic with meta.yml citations"() {
+        given:
+        def fastqcMeta = new File(tempDir.toFile(), 'fastqc_meta.yml')
+        fastqcMeta << '''
+        name: fastqc
+        tools:
+          - fastqc:
+              doi: "10.1093/bioinformatics/btv033"
+              homepage: "https://www.bioinformatics.babraham.ac.uk/projects/fastqc/"
+        '''.stripIndent()
+        def samtoolsMeta = new File(tempDir.toFile(), 'samtools_meta.yml')
+        samtoolsMeta << '''
+        name: samtools
+        tools:
+          - samtools:
+              doi: "10.1093/bioinformatics/btp352"
+        '''.stripIndent()
+
+        // Only FASTQC actually ran in this pipeline execution
+        def topicVersions = [
+            ['NFCORE_TEST:FASTQC', 'fastqc', '0.12.1']
+        ]
+        def metaPaths = [fastqcMeta.absolutePath, samtoolsMeta.absolutePath]
+
+        when:
+        def result = NfcoreCitationUtils.citationsOnTheFly(topicVersions, metaPaths)
+
+        then:
+        result.containsKey('fastqc')
+        !result.containsKey('samtools') // present in meta.yml but did not run
+        result.fastqc.citation.contains('fastqc')
+
+        and: 'the descriptive alias delegates to the same behaviour'
+        NfcoreCitationUtils.citationsForToolsUsed(topicVersions, metaPaths) == result
+    }
+
     // Helper method to create mock meta.yml files for testing
     private String createMockMetaYml(String toolName) {
         def tempFile = File.createTempFile("${toolName}_meta", '.yml')

--- a/src/test/groovy/nfcore/plugin/nfcore/NfcoreCitationUtilsTest.groovy
+++ b/src/test/groovy/nfcore/plugin/nfcore/NfcoreCitationUtilsTest.groovy
@@ -930,6 +930,66 @@ ${tool_bibliography}
         result.fastqc.citation.contains('fastqc')
     }
 
+    // --- Publication-style short citations (version + short author) ---
+
+    def "toolVersionsFromTopic maps tool names to versions"() {
+        given:
+        def topicVersions = [
+            ['NFCORE:FASTQC', 'fastqc', '0.12.1'],
+            ['NFCORE:MULTIQC', 'multiqc', '1.21'],
+            ['NFCORE:FASTQC', 'fastqc', '0.12.1'] // duplicate
+        ]
+
+        expect:
+        NfcoreCitationUtils.toolVersionsFromTopic(topicVersions) == ['fastqc': '0.12.1', 'multiqc': '1.21']
+    }
+
+    def "formatShortCitation includes version and a single short author with year"() {
+        expect:
+        NfcoreCitationUtils.formatShortCitation('fastqc', [author: 'Andrews S', year: 2010], '0.12.1') == 'fastqc (0.12.1, Andrews 2010)'
+    }
+
+    def "formatShortCitation uses 'et al.' for multiple authors"() {
+        expect:
+        NfcoreCitationUtils.formatShortCitation('samtools', [author: 'Danecek P, Bonfield JK, et al.', year: 2021], '1.21') == 'samtools (1.21, Danecek et al. 2021)'
+    }
+
+    def "formatShortCitation falls back to doi then url when no author"() {
+        expect:
+        NfcoreCitationUtils.formatShortCitation('multiqc', [doi: '10.1093/bioinformatics/btw354'], '1.21') == 'multiqc (1.21, doi: 10.1093/bioinformatics/btw354)'
+        NfcoreCitationUtils.formatShortCitation('seqtk', [homepage: 'https://github.com/lh3/seqtk'], '1.4') == 'seqtk (1.4, https://github.com/lh3/seqtk)'
+    }
+
+    def "formatShortCitation omits the version segment when no version is known"() {
+        expect:
+        NfcoreCitationUtils.formatShortCitation('fastqc', [author: 'Andrews S', year: 2010], null) == 'fastqc (Andrews 2010)'
+    }
+
+    def "citationsOnTheFly produces publication-style short citations with version"() {
+        given:
+        def fastqcMeta = new File(tempDir.toFile(), 'fastqc_meta.yml')
+        fastqcMeta << '''
+        name: fastqc
+        tools:
+          - fastqc:
+              author: "Andrews S"
+              year: 2010
+              doi: "10.1093/bioinformatics/btv033"
+              homepage: "https://www.bioinformatics.babraham.ac.uk/projects/fastqc/"
+        '''.stripIndent()
+        def topicVersions = [['NFCORE:FASTQC', 'fastqc', '0.12.1']]
+
+        when:
+        def result = NfcoreCitationUtils.citationsOnTheFly(topicVersions, [fastqcMeta.absolutePath])
+
+        then: 'short citation is copy-paste ready: tool (version, Author year)'
+        result.fastqc.citation == 'fastqc (0.12.1, Andrews 2010)'
+
+        and: 'the full bibliography is unchanged'
+        result.fastqc.bibliography.contains('<li>')
+        result.fastqc.bibliography.contains('Andrews S')
+    }
+
     // --- log capture helpers ---
 
     private ListAppender<ILoggingEvent> captureLogsFor(Class clazz) {

--- a/validation/README.md
+++ b/validation/README.md
@@ -69,6 +69,19 @@ Tests essential pipeline utility functions:
 - `getWorkflowVersion()` - Version string generation
 - `dumpParametersToJSON()` - Parameter file creation
 
+### 📚 citations-on-the-fly/
+
+**Citations on the Fly (versions-topic-driven)**
+
+Tests `citationsOnTheFly()` — citations built from the tools that actually ran
+(the `versions` topic) with metadata resolved from each module's `meta.yml`.
+
+**Key validations:**
+
+- `citationsOnTheFly(topicVersions, metaFilePaths)` cites only the tools that ran
+- `toolCitationText()` / `toolBibliographyText()` render the selected citations
+- A tool with a `meta.yml` that did not run (`STAR_ALIGN`, gated off) is not cited
+
 ### 🚧 Future Validation Tests
 
 Additional validation tests can be added following the same pattern:

--- a/validation/citations-on-the-fly/README.md
+++ b/validation/citations-on-the-fly/README.md
@@ -1,0 +1,27 @@
+# citations-on-the-fly/
+
+**Pattern: Citations on the Fly (versions-topic-driven)**
+
+Demonstrates `citationsOnTheFly()` — citations generated from the tools that
+*actually ran*, with their metadata resolved from each module's `meta.yml`.
+
+Unlike [`topic-channel-citations/`](../topic-channel-citations/), the modules
+here do **not** emit a dedicated `citation` topic. They only emit the standard
+`versions` topic (`[process, tool, version]`) that every nf-core module already
+produces. This means citations need **zero per-module changes** beyond the
+versions reporting modules already do.
+
+## Key validations
+
+- `citationsOnTheFly(topicVersions, metaFilePaths)` cites exactly the tools that ran.
+- `toolCitationText()` / `toolBibliographyText()` render the selected citations.
+- A tool with a `meta.yml` that **did not run** (`STAR_ALIGN`, gated off by
+  `params.run_optional = false`) is **not** cited — proving citations track
+  execution, not the module inventory.
+
+## Run
+
+```bash
+make install
+cd validation && nf-test test citations-on-the-fly/main.nf.test
+```

--- a/validation/citations-on-the-fly/README.md
+++ b/validation/citations-on-the-fly/README.md
@@ -3,7 +3,7 @@
 **Pattern: Citations on the Fly (versions-topic-driven)**
 
 Demonstrates `citationsOnTheFly()` — citations generated from the tools that
-*actually ran*, with their metadata resolved from each module's `meta.yml`.
+_actually ran_, with their metadata resolved from each module's `meta.yml`.
 
 Unlike [`topic-channel-citations/`](../topic-channel-citations/), the modules
 here do **not** emit a dedicated `citation` topic. They only emit the standard

--- a/validation/citations-on-the-fly/main.nf
+++ b/validation/citations-on-the-fly/main.nf
@@ -61,7 +61,7 @@ workflow {
             log.info("=== Cited tools (ran + have meta.yml): ${citations.keySet().sort().join(', ')} ===")
             [
                 citation_text: toolCitationText(citations),
-                bibliography : toolBibliographyText(citations),
+                bibliography: toolBibliographyText(citations),
             ]
         }
 

--- a/validation/citations-on-the-fly/main.nf
+++ b/validation/citations-on-the-fly/main.nf
@@ -54,11 +54,12 @@ workflow {
 
     // Build citations from the tools that actually ran (the versions topic).
     // collect(flat: false) preserves each [process, tool, version] tuple.
+    // multiqcsav is a MultiQC plugin (no process, no version) — add it manually.
     ch_citations = channel.topic('versions')
         .collect(flat: false)
         .map { versions ->
-            def citations = citationsOnTheFly(versions, meta_yml_paths)
-            log.info("=== Cited tools (ran + have meta.yml): ${citations.keySet().sort().join(', ')} ===")
+            def citations = citationsOnTheFly(versions, meta_yml_paths, ['multiqcsav'])
+            log.info("=== Cited tools: ${citations.keySet().sort().join(', ')} ===")
             [
                 citation_text: toolCitationText(citations),
                 bibliography: toolBibliographyText(citations),

--- a/validation/citations-on-the-fly/main.nf
+++ b/validation/citations-on-the-fly/main.nf
@@ -1,0 +1,108 @@
+#!/usr/bin/env nextflow
+
+/*
+ * E2E validation test for "citations on the fly".
+ *
+ * Unlike the topic-channel-citations test, the modules here do NOT emit a
+ * dedicated `citation` topic. They only emit the standard `versions` topic
+ * ([process, tool, version]) that every nf-core module already produces when
+ * it runs. citationsOnTheFly() intersects that list of tools-that-ran with the
+ * citations parsed from each module's meta.yml, so citations reflect exactly
+ * what executed — with zero per-module changes.
+ */
+
+include { citationsOnTheFly    } from 'plugin/nf-core-utils'
+include { toolCitationText     } from 'plugin/nf-core-utils'
+include { toolBibliographyText } from 'plugin/nf-core-utils'
+
+include { FASTQC               } from './modules/local/fastqc/main'
+include { MULTIQC              } from './modules/local/multiqc/main'
+include { SAMTOOLS_VIEW        } from './modules/local/samtools/view/main'
+include { STAR_ALIGN           } from './modules/local/star/align/main'
+
+workflow {
+
+    log.info(
+        """
+        ==========================================
+        nf-core-utils Citations on the Fly E2E Test
+        ==========================================
+
+        This test demonstrates citations driven by the versions topic:
+        1. Modules emit only [process, tool, version] to the versions topic
+        2. citationsOnTheFly() resolves citation metadata from meta.yml
+        3. Only tools that actually ran are cited
+        """.stripIndent().trim()
+    )
+
+    // Create sample data
+    samples = Channel.of('sample1', 'sample2', 'sample3')
+
+    // Run processes - each emits its version to the `versions` topic when it runs
+    fastqc_out = FASTQC(samples)
+    SAMTOOLS_VIEW(samples)
+    MULTIQC(fastqc_out.html.collect())
+
+    // STAR has a meta.yml but is OFF: it must not appear in the citations
+    if (params.run_optional) {
+        STAR_ALIGN(samples.first())
+    }
+
+    // Citation metadata source: every module meta.yml under this pipeline.
+    // files() returns an empty list when nothing matches the glob.
+    def meta_yml_paths = files("${projectDir}/modules/**/meta.yml").collect { it.toString() }
+
+    // Build citations from the tools that actually ran (the versions topic).
+    // collect(flat: false) preserves each [process, tool, version] tuple.
+    ch_citations = channel.topic('versions')
+        .collect(flat: false)
+        .map { versions ->
+            def citations = citationsOnTheFly(versions, meta_yml_paths)
+            log.info("=== Cited tools (ran + have meta.yml): ${citations.keySet().sort().join(', ')} ===")
+            [
+                citation_text: toolCitationText(citations),
+                bibliography : toolBibliographyText(citations),
+            ]
+        }
+
+    // Write outputs and demonstrate usage
+    ch_citations.subscribe { citations ->
+        log.info(
+            """
+            ==========================================
+            CITATIONS ON THE FLY RESULTS
+            ==========================================
+
+            Citation Text:
+            ${citations.citation_text}
+
+            Bibliography:
+            ${citations.bibliography}
+
+            ==========================================
+            """.stripIndent().trim()
+        )
+
+        def output_dir = params.outdir
+        new File(output_dir).mkdirs()
+        new File("${output_dir}/auto_citations.txt").text = citations.citation_text
+        new File("${output_dir}/auto_bibliography.html").text = citations.bibliography
+
+        log.info("✅ Citations written to: ${output_dir}/")
+    }
+
+    workflow.onComplete {
+        log.info(
+            """
+            ==========================================
+            Citations on the Fly Test Complete!
+            ==========================================
+
+            ✅ Citations derived from the versions topic (tools that ran)
+            ✅ Metadata resolved from module meta.yml — no hand-maintained list
+            ✅ STAR has a meta.yml but did not run, so it is not cited
+            ==========================================
+            """.stripIndent().trim()
+        )
+    }
+}

--- a/validation/citations-on-the-fly/main.nf.test
+++ b/validation/citations-on-the-fly/main.nf.test
@@ -1,0 +1,37 @@
+nextflow_pipeline {
+
+    name "Test nf-core-utils citations on the fly (versions-topic-driven)"
+    script "./main.nf"
+    config "./nextflow.config"
+
+    test("Citations reflect only the tools that ran") {
+
+        when {
+            params {
+                validate_params = false
+                outdir = "$outputDir"
+            }
+        }
+
+        then {
+            assert workflow.success
+
+            def citations = path("${params.outdir}/auto_citations.txt").text
+            def bibliography = path("${params.outdir}/auto_bibliography.html").text
+
+            // Tools that ran (have a versions emission + a meta.yml) are cited
+            assert citations.contains('fastqc')
+            assert citations.contains('multiqc')
+            assert citations.contains('samtools')
+
+            // STAR has a meta.yml but did NOT run, so it must not be cited
+            assert !citations.toLowerCase().contains('star')
+            assert !bibliography.contains('bts635') // STAR DOI absent
+
+            assert snapshot(
+                path("${params.outdir}/auto_citations.txt").text,
+                path("${params.outdir}/auto_bibliography.html").text,
+            ).match()
+        }
+    }
+}

--- a/validation/citations-on-the-fly/main.nf.test
+++ b/validation/citations-on-the-fly/main.nf.test
@@ -24,6 +24,9 @@ nextflow_pipeline {
             assert citations.contains('multiqc')
             assert citations.contains('samtools')
 
+            // multiqcsav has no process/version but is added manually via extraTools
+            assert citations.contains('multiqcsav')
+
             // STAR has a meta.yml but did NOT run, so it must not be cited
             assert !citations.toLowerCase().contains('star')
             assert !bibliography.contains('bts635') // STAR DOI absent

--- a/validation/citations-on-the-fly/main.nf.test.snap
+++ b/validation/citations-on-the-fly/main.nf.test.snap
@@ -1,10 +1,10 @@
 {
     "Citations reflect only the tools that ran": {
         "content": [
-            "Tools used in the workflow included: fastqc (DOI: 10.1093/bioinformatics/btw354), multiqc (DOI: 10.1093/bioinformatics/btw354), samtools (DOI: 10.1093/bioinformatics/btp352).",
-            "<li>fastqc. doi: 10.1093/bioinformatics/btw354. <a href='https://www.bioinformatics.babraham.ac.uk/projects/fastqc/'>https://www.bioinformatics.babraham.ac.uk/projects/fastqc/</a></li> <li>multiqc. doi: 10.1093/bioinformatics/btw354. <a href='https://multiqc.info/'>https://multiqc.info/</a></li> <li>samtools. doi: 10.1093/bioinformatics/btp352. <a href='http://www.htslib.org/'>http://www.htslib.org/</a></li>"
+            "Tools used in the workflow included: fastqc (0.12.1, Andrews 2010), multiqc (1.21, doi: 10.1093/bioinformatics/btw354), samtools (1.21, Danecek et al. 2021).",
+            "<li>Andrews S. 2010. fastqc. doi: 10.1093/bioinformatics/btw354. <a href='https://www.bioinformatics.babraham.ac.uk/projects/fastqc/'>https://www.bioinformatics.babraham.ac.uk/projects/fastqc/</a></li> <li>multiqc. doi: 10.1093/bioinformatics/btw354. <a href='https://multiqc.info/'>https://multiqc.info/</a></li> <li>Danecek P, Bonfield JK, Liddle J, et al.. 2021. samtools. doi: 10.1093/bioinformatics/btp352. <a href='http://www.htslib.org/'>http://www.htslib.org/</a></li>"
         ],
-        "timestamp": "2026-06-15T13:42:06.856088",
+        "timestamp": "2026-06-16T07:16:59.380415",
         "meta": {
             "nf-test": "0.9.5",
             "nextflow": "25.10.3"

--- a/validation/citations-on-the-fly/main.nf.test.snap
+++ b/validation/citations-on-the-fly/main.nf.test.snap
@@ -1,10 +1,10 @@
 {
     "Citations reflect only the tools that ran": {
         "content": [
-            "Tools used in the workflow included: fastqc (0.12.1, Andrews 2010), multiqc (1.21, doi: 10.1093/bioinformatics/btw354), samtools (1.21, Danecek et al. 2021).",
-            "<li>Andrews S. 2010. fastqc. doi: 10.1093/bioinformatics/btw354. <a href='https://www.bioinformatics.babraham.ac.uk/projects/fastqc/'>https://www.bioinformatics.babraham.ac.uk/projects/fastqc/</a></li> <li>multiqc. doi: 10.1093/bioinformatics/btw354. <a href='https://multiqc.info/'>https://multiqc.info/</a></li> <li>Danecek P, Bonfield JK, Liddle J, et al.. 2021. samtools. doi: 10.1093/bioinformatics/btp352. <a href='http://www.htslib.org/'>http://www.htslib.org/</a></li>"
+            "Tools used in the workflow included: fastqc (0.12.1, Andrews 2010), multiqc (1.21, doi: 10.1093/bioinformatics/btw354), multiqcsav (https://github.com/MultiQC/MultiQC_SAV/), samtools (1.21, Danecek et al. 2021).",
+            "<li>Andrews S. 2010. fastqc. doi: 10.1093/bioinformatics/btw354. <a href='https://www.bioinformatics.babraham.ac.uk/projects/fastqc/'>https://www.bioinformatics.babraham.ac.uk/projects/fastqc/</a></li> <li>multiqc. doi: 10.1093/bioinformatics/btw354. <a href='https://multiqc.info/'>https://multiqc.info/</a></li> <li>multiqcsav. <a href='https://github.com/MultiQC/MultiQC_SAV/'>https://github.com/MultiQC/MultiQC_SAV/</a></li> <li>Danecek P, Bonfield JK, Liddle J, et al.. 2021. samtools. doi: 10.1093/bioinformatics/btp352. <a href='http://www.htslib.org/'>http://www.htslib.org/</a></li>"
         ],
-        "timestamp": "2026-06-16T07:16:59.380415",
+        "timestamp": "2026-06-16T08:04:06.469699",
         "meta": {
             "nf-test": "0.9.5",
             "nextflow": "25.10.3"

--- a/validation/citations-on-the-fly/main.nf.test.snap
+++ b/validation/citations-on-the-fly/main.nf.test.snap
@@ -1,0 +1,13 @@
+{
+    "Citations reflect only the tools that ran": {
+        "content": [
+            "Tools used in the workflow included: fastqc (DOI: 10.1093/bioinformatics/btw354), multiqc (DOI: 10.1093/bioinformatics/btw354), samtools (DOI: 10.1093/bioinformatics/btp352).",
+            "<li>fastqc. doi: 10.1093/bioinformatics/btw354. <a href='https://www.bioinformatics.babraham.ac.uk/projects/fastqc/'>https://www.bioinformatics.babraham.ac.uk/projects/fastqc/</a></li> <li>multiqc. doi: 10.1093/bioinformatics/btw354. <a href='https://multiqc.info/'>https://multiqc.info/</a></li> <li>samtools. doi: 10.1093/bioinformatics/btp352. <a href='http://www.htslib.org/'>http://www.htslib.org/</a></li>"
+        ],
+        "timestamp": "2026-06-15T13:42:06.856088",
+        "meta": {
+            "nf-test": "0.9.5",
+            "nextflow": "25.10.3"
+        }
+    }
+}

--- a/validation/citations-on-the-fly/modules/local/fastqc/main.nf
+++ b/validation/citations-on-the-fly/modules/local/fastqc/main.nf
@@ -1,0 +1,16 @@
+process FASTQC {
+    tag "${sample_id}"
+    label 'process_medium'
+
+    input:
+    val sample_id
+
+    output:
+    path "*.html", emit: html
+    tuple val("${task.process}"), val('fastqc'), val('0.12.1'), topic: versions
+
+    script:
+    """
+    echo "<html>FastQC Report for ${sample_id}</html>" > ${sample_id}_fastqc.html
+    """
+}

--- a/validation/citations-on-the-fly/modules/local/fastqc/meta.yml
+++ b/validation/citations-on-the-fly/modules/local/fastqc/meta.yml
@@ -1,0 +1,14 @@
+name: fastqc
+description: "Run FastQC on sequenced reads"
+keywords:
+  - quality control
+  - qc
+  - fastq
+tools:
+  - fastqc:
+      description: "A quality control tool for high throughput sequence data."
+      homepage: "https://www.bioinformatics.babraham.ac.uk/projects/fastqc/"
+      documentation: "https://www.bioinformatics.babraham.ac.uk/projects/fastqc/Help/"
+      tool_dev_url: "https://www.bioinformatics.babraham.ac.uk/projects/fastqc/"
+      doi: "10.1093/bioinformatics/btw354"
+      licence: "GPL v3"

--- a/validation/citations-on-the-fly/modules/local/fastqc/meta.yml
+++ b/validation/citations-on-the-fly/modules/local/fastqc/meta.yml
@@ -11,4 +11,6 @@ tools:
       documentation: "https://www.bioinformatics.babraham.ac.uk/projects/fastqc/Help/"
       tool_dev_url: "https://www.bioinformatics.babraham.ac.uk/projects/fastqc/"
       doi: "10.1093/bioinformatics/btw354"
+      author: "Andrews S"
+      year: 2010
       licence: "GPL v3"

--- a/validation/citations-on-the-fly/modules/local/multiqc/main.nf
+++ b/validation/citations-on-the-fly/modules/local/multiqc/main.nf
@@ -1,0 +1,15 @@
+process MULTIQC {
+    label 'process_medium'
+
+    input:
+    path fastqc_files
+
+    output:
+    path "*.html", emit: report
+    tuple val("${task.process}"), val('multiqc'), val('1.21'), topic: versions
+
+    script:
+    """
+    echo "<html>MultiQC Report</html>" > multiqc_report.html
+    """
+}

--- a/validation/citations-on-the-fly/modules/local/multiqc/meta.yml
+++ b/validation/citations-on-the-fly/modules/local/multiqc/meta.yml
@@ -1,0 +1,15 @@
+name: multiqc
+description: "MultiQC searches a given directory for analysis logs and compiles a HTML report"
+keywords:
+  - quality control
+  - qc
+  - report
+  - html
+tools:
+  - multiqc:
+      description: "MultiQC searches a given directory for analysis logs and compiles a HTML report."
+      homepage: "https://multiqc.info/"
+      documentation: "https://multiqc.info/docs/"
+      tool_dev_url: "https://github.com/ewels/MultiQC"
+      doi: "10.1093/bioinformatics/btw354"
+      licence: "GPL v3"

--- a/validation/citations-on-the-fly/modules/local/multiqcsav/meta.yml
+++ b/validation/citations-on-the-fly/modules/local/multiqcsav/meta.yml
@@ -1,0 +1,10 @@
+name: multiqcsav
+description: "MultiQC plugin for Illumina Sequencing Analysis Viewer (SAV)"
+keywords:
+  - multiqc
+  - illumina
+  - sav
+tools:
+  - multiqcsav:
+      description: "MultiQC plugin for Illumina Sequencing Analysis Viewer."
+      homepage: "https://github.com/MultiQC/MultiQC_SAV/"

--- a/validation/citations-on-the-fly/modules/local/samtools/view/main.nf
+++ b/validation/citations-on-the-fly/modules/local/samtools/view/main.nf
@@ -1,0 +1,16 @@
+process SAMTOOLS_VIEW {
+    tag "${sample_id}"
+    label 'process_low'
+
+    input:
+    val sample_id
+
+    output:
+    path "*.sam", emit: sam
+    tuple val("${task.process}"), val('samtools'), val('1.21'), topic: versions
+
+    script:
+    """
+    echo "SAM data for ${sample_id}" > ${sample_id}.sam
+    """
+}

--- a/validation/citations-on-the-fly/modules/local/samtools/view/meta.yml
+++ b/validation/citations-on-the-fly/modules/local/samtools/view/meta.yml
@@ -1,0 +1,14 @@
+name: samtools_view
+description: "Filter SAM/BAM files"
+keywords:
+  - view
+  - bam
+  - sam
+tools:
+  - samtools:
+      description: "Tools for dealing with SAM, BAM and CRAM files"
+      homepage: "http://www.htslib.org/"
+      documentation: "http://www.htslib.org/doc/samtools.html"
+      tool_dev_url: "https://github.com/samtools/samtools"
+      doi: "10.1093/bioinformatics/btp352"
+      licence: "MIT"

--- a/validation/citations-on-the-fly/modules/local/samtools/view/meta.yml
+++ b/validation/citations-on-the-fly/modules/local/samtools/view/meta.yml
@@ -11,4 +11,6 @@ tools:
       documentation: "http://www.htslib.org/doc/samtools.html"
       tool_dev_url: "https://github.com/samtools/samtools"
       doi: "10.1093/bioinformatics/btp352"
+      author: "Danecek P, Bonfield JK, Liddle J, et al."
+      year: 2021
       licence: "MIT"

--- a/validation/citations-on-the-fly/modules/local/star/align/main.nf
+++ b/validation/citations-on-the-fly/modules/local/star/align/main.nf
@@ -1,0 +1,16 @@
+process STAR_ALIGN {
+    tag "${sample_id}"
+    label 'process_high'
+
+    input:
+    val sample_id
+
+    output:
+    path "*.txt", emit: result
+    tuple val("${task.process}"), val('star'), val('2.7.11b'), topic: versions
+
+    script:
+    """
+    echo "STAR alignment output for ${sample_id}" > ${sample_id}_star.txt
+    """
+}

--- a/validation/citations-on-the-fly/modules/local/star/align/meta.yml
+++ b/validation/citations-on-the-fly/modules/local/star/align/meta.yml
@@ -1,0 +1,14 @@
+name: star_align
+description: "Map sequencing reads to a reference genome with STAR"
+keywords:
+  - alignment
+  - rna-seq
+  - star
+tools:
+  - star:
+      description: "STAR is a fast RNA-seq read mapper, with support for splice-junction and fusion read detection"
+      homepage: "https://github.com/alexdobin/STAR"
+      documentation: "https://physiology.med.cornell.edu/faculty/skrabanek/lab/angsd/lecture_notes/STARmanual.pdf"
+      tool_dev_url: "https://github.com/alexdobin/STAR"
+      doi: "10.1093/bioinformatics/bts635"
+      licence: "MIT"

--- a/validation/citations-on-the-fly/nextflow.config
+++ b/validation/citations-on-the-fly/nextflow.config
@@ -1,0 +1,28 @@
+// Configuration for "citations on the fly" validation test
+//
+// Citations are derived from the `versions` topic (the tools that actually ran)
+// and resolved from each module's meta.yml — no per-module citation emission.
+
+params {
+    // STAR is optional and OFF by default: its meta.yml exists but it never runs,
+    // so it must NOT appear in the citations.
+    run_optional = false
+}
+
+// Plugin configuration
+plugins {
+    id 'nf-core-utils@0.5.0'
+}
+
+manifest {
+    name        = 'nf-core-utils-citations-on-the-fly-test'
+    description = 'Validation test for versions-topic-driven citations'
+    version     = '1.0.0'
+}
+
+// Process configuration
+process {
+    cpus   = 1
+    memory = '1 GB'
+    time   = '5 min'
+}


### PR DESCRIPTION
## Overview

Adds **citations on the fly** to the plugin: tool citations are derived from the tools that *actually ran* and resolved from each module's `meta.yml` — so a pipeline's methods description cites exactly what executed, with **no per-module changes**.

Generalises the pattern from [nf-core/seqinspector#237](https://github.com/nf-core/seqinspector/pull/237) into a reusable plugin function, but uses canonical `meta.yml` as the citation source instead of a hand-maintained reference map.

## How it works

Every nf-core module already emits `[process, tool, version]` to the `versions` topic when it runs. `citationsOnTheFly()` intersects that list with citations parsed from the supplied `meta.yml` files, so only executed tools are cited.

```groovy
include { citationsOnTheFly; methodsDescriptionText } from 'plugin/nf-core-utils'

def meta_yml_paths = files("${projectDir}/modules/**/meta.yml").collect { it.toString() }

ch_methods_description = channel.topic('versions')
    .collect(flat: false)   // preserve [process, tool, version] tuples
    .map { versions ->
        def citations = citationsOnTheFly(versions, meta_yml_paths)
        methodsDescriptionText("${projectDir}/assets/methods_description_template.yml", citations, [:])
    }
```

## What changed

- **`NfcoreCitationUtils`** — three composable methods:
  - `toolsFromVersionsTopic(topicVersions)` — unique tool names that ran
  - `filterCitationsByTools(allCitations, toolsUsed)` — intersect (exact then case-insensitive; warns on tools with no `meta.yml` entry)
  - `citationsOnTheFly(topicVersions, metaFilePaths)` — entry point; output feeds the existing `toolCitationText` / `toolBibliographyText` / `methodsDescriptionText`
- Exposed `citationsOnTheFly` and `toolsFromVersionsTopic` as `@Function`s on `NfUtilsExtension`.
- Docs: a "Citations on the Fly" section in `docs/utilities/NfcoreCitationUtils.md` and the utilities index.
- Validation: new `validation/citations-on-the-fly/` E2E whose modules emit only the `versions` topic; `STAR_ALIGN` has a `meta.yml` but is gated off, proving a non-executed tool is **not** cited.

## Reviewer notes

- **`.collect(flat: false)` is required** — plain `.collect()` flattens the tuples into loose scalars. `toolsFromVersionsTopic` logs a warning if it receives flattened data, turning a silent empty-citations no-op into actionable guidance.
- **Tool-name matching** is exact-then-case-insensitive; a tool that ran but lacks a `meta.yml` citation entry is logged so authors can add it.
- Citations are computed **once per run** at completion (not a hot path).
- Pre-existing, not introduced here: meta.yml parsing uses SnakeYAML's `Yaml().load()` — `meta.yml` is trusted/in-repo, but worth a follow-up to switch to `SafeConstructor`.

## Testing

- Unit suite: **230 tests, 0 failed** (Spock), including log-capture tests for the warning paths.
- Validation E2E passes with a reviewable content snapshot (`fastqc`, `multiqc`, `samtools` cited; `star` excluded).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
