### PR TITLE
feat: add File overload for methodsDescriptionText

### DIFF
--- a/src/main/groovy/nfcore/plugin/NfUtilsExtension.groovy
+++ b/src/main/groovy/nfcore/plugin/NfUtilsExtension.groovy
@@ -388,7 +388,7 @@ class NfUtilsExtension extends PluginExtensionPoint {
     /**
      * Generate methods description text using collected citations
      *
-     * @param mqcMethodsYaml MultiQC methods YAML file path
+     * @param mqcMethodsYamlPath MultiQC methods YAML file path as String
      * @param collectedCitations Map containing all tool citations from modules (optional)
      * @param meta Additional metadata (optional)
      * @return Formatted methods description HTML
@@ -397,6 +397,19 @@ class NfUtilsExtension extends PluginExtensionPoint {
     String methodsDescriptionText(String mqcMethodsYamlPath, Map collectedCitations = [:], Map meta = [:]) {
         def mqcFile = new File(mqcMethodsYamlPath)
         return NfcoreCitationUtils.methodsDescriptionText(mqcFile, collectedCitations, meta)
+    }
+
+    /**
+     * Generate methods description text using collected citations
+     *
+     * @param mqcMethodsYaml MultiQC methods YAML file
+     * @param collectedCitations Map containing all tool citations from modules (optional)
+     * @param meta Additional metadata (optional)
+     * @return Formatted methods description HTML
+     */
+    @Function
+    String methodsDescriptionText(File mqcMethodsYaml, Map collectedCitations = [:], Map meta = [:]) {
+        return NfcoreCitationUtils.methodsDescriptionText(mqcMethodsYaml, collectedCitations, meta)
     }
 
     /**


### PR DESCRIPTION
Allow passing a `File` object directly to `methodsDescriptionText` in addition to a `String` path.

## Motivation
When working with Nextflow `Path` objects (e.g., from `file()` or `Channel`), users had to convert to `String` before calling `methodsDescriptionText`. This overload accepts `File` directly for convenience.

## Changes
- Added overloaded `methodsDescriptionText(File, Map, Map)` to `NfUtilsExtension`
- Existing `methodsDescriptionText(String, Map, Map)` unchanged

## Checklist
- [x] Tests pass (`make test`)
- [x] Backward compatible