### PR TITLE
fix: correct malformed HTML in paramsSummaryMultiqc N/A fallback

### DIFF
--- a/src/main/groovy/nfcore/plugin/nfcore/NfcoreReportingUtils.groovy
+++ b/src/main/groovy/nfcore/plugin/nfcore/NfcoreReportingUtils.groovy
@@ -48,7 +48,7 @@ class NfcoreReportingUtils {
                                 .keySet()
                                 .sort()
                                 .each { param ->
-                                    summarySection += "        <dt>${param}</dt><dd><samp>${groupParams.get(param) ?: '<span style=\"color:#999999;\">N/A</a>'}</samp></dd>\n"
+                                    summarySection += "        <dt>${param}</dt><dd><samp>${groupParams.get(param) ?: '<span style=\"color:#999999;\">N/A</span>'}</samp></dd>\n"
                                 }
                         summarySection += "    </dl>\n"
                     }

--- a/src/test/groovy/nfcore/plugin/nfcore/NfcoreReportingUtilsTest.groovy
+++ b/src/test/groovy/nfcore/plugin/nfcore/NfcoreReportingUtilsTest.groovy
@@ -128,7 +128,7 @@ class NfcoreReportingUtilsTest extends Specification {
         result.contains("<dt>param1</dt><dd><samp>value1</samp></dd>")
 
         // Null parameter shows N/A
-        result.contains("<dt>param2</dt><dd><samp><span style=\"color:#999999;\">N/A</a></samp></dd>")
+        result.contains("<dt>param2</dt><dd><samp><span style=\"color:#999999;\">N/A</span></samp></dd>")
 
         cleanup:
         // Restore original method


### PR DESCRIPTION
Fix unclosed `</a>` tag to properly closed `</span>` in the N/A display fallback for null parameter values.

## Changes
- Fixed HTML tag in `NfcoreReportingUtils.paramsSummaryMultiqc()`
- Updated corresponding test expectation

## Checklist
- [x] Tests pass (`make test`)
- [x] Backward compatible