### PR TITLE
fix: correct malformed HTML in paramsSummaryMultiqc N/A fallback

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 - Fixed `dumpParametersToJSON()` to serialize Nextflow parameter types and copy parameter reports through Nextflow file handling for cloud/remote paths.
+- Fixed malformed HTML tag (`</a>` → `</span>`) in `paramsSummaryMultiqc()` N/A fallback for null parameter values ([#50](https://github.com/nf-core/nf-core-utils/pull/50)).
 
 ## [0.4.0] - 2025-10-31
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,7 +22,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 - Fixed `dumpParametersToJSON()` to serialize Nextflow parameter types and copy parameter reports through Nextflow file handling for cloud/remote paths.
-- Fixed malformed HTML tag (`</a>` → `</span>`) in `paramsSummaryMultiqc()` N/A fallback for null parameter values ([#50](https://github.com/nf-core/nf-core-utils/pull/50)).
+- Fixed malformed HTML tag (`</a>` → `</span>`) in `paramsSummaryMultiqc()`.
 
 ## [0.4.0] - 2025-10-31
 

--- a/src/main/groovy/nfcore/plugin/nfcore/NfcoreReportingUtils.groovy
+++ b/src/main/groovy/nfcore/plugin/nfcore/NfcoreReportingUtils.groovy
@@ -48,7 +48,7 @@ class NfcoreReportingUtils {
                                 .keySet()
                                 .sort()
                                 .each { param ->
-                                    summarySection += "        <dt>${param}</dt><dd><samp>${groupParams.get(param) ?: '<span style=\"color:#999999;\">N/A</a>'}</samp></dd>\n"
+                                    summarySection += "        <dt>${param}</dt><dd><samp>${groupParams.get(param) ?: '<span style=\"color:#999999;\">N/A</span>'}</samp></dd>\n"
                                 }
                         summarySection += "    </dl>\n"
                     }

--- a/src/test/groovy/nfcore/plugin/nfcore/NfcoreReportingUtilsTest.groovy
+++ b/src/test/groovy/nfcore/plugin/nfcore/NfcoreReportingUtilsTest.groovy
@@ -128,7 +128,7 @@ class NfcoreReportingUtilsTest extends Specification {
         result.contains("<dt>param1</dt><dd><samp>value1</samp></dd>")
 
         // Null parameter shows N/A
-        result.contains("<dt>param2</dt><dd><samp><span style=\"color:#999999;\">N/A</a></samp></dd>")
+        result.contains("<dt>param2</dt><dd><samp><span style=\"color:#999999;\">N/A</span></samp></dd>")
 
         cleanup:
         // Restore original method


### PR DESCRIPTION
Fix unclosed `</a>` tag to properly closed `</span>` in the N/A display fallback for null parameter values.

## Changes
- Fixed HTML tag in `NfcoreReportingUtils.paramsSummaryMultiqc()`
- Updated corresponding test expectation

## Checklist
- [x] Tests pass (`make test`)
- [x] Backward compatible